### PR TITLE
docs(goap-planner): refresh perf numbers with 2026-05-02 validation re-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Last measured 2026-05-02 on macOS / Rust stable.
 
 | Workload | Result |
 |---|---|
-| 5-step linear plan | **3.4 µs** |
-| 50-step linear plan | **33 µs** |
-| 128-action library, single correct branch | **362 µs** |
-| 16 redundant paths, picks the cheapest | **24 µs** |
-| Goal already satisfied (fast-path early return) | **6.9 ns** |
-| `Action::applicable` (preconditions met / unmet) | **17 ns / 14 ns** |
-| 64 concurrent plans via Rayon over `Arc<Planner>` | **145 µs** (5.4× faster than sequential) |
+| 5-step linear plan | **3.3 µs** |
+| 50-step linear plan | **32 µs** |
+| 128-action library, single correct branch | **337 µs** |
+| 16 redundant paths, picks the cheapest | **23 µs** |
+| Goal already satisfied (fast-path early return) | **7.2 ns** |
+| `Action::applicable` (preconditions met / unmet) | **16 ns / 13 ns** |
+| 64 concurrent plans via Rayon over `Arc<Planner>` | **148 µs** (5.2× faster than sequential) |
 
 Canonical summary: [`goap-planner/docs/performance.md`](goap-planner/docs/performance.md).
 

--- a/goap-planner/README.md
+++ b/goap-planner/README.md
@@ -62,15 +62,15 @@ All figures from `cargo bench -p goap-planner` (Criterion 0.5, 100 samples, rele
 
 | Scenario | Result |
 |---|---|
-| 5-step linear plan | **3.4 µs** |
-| 50-step linear plan | **33 µs** |
-| 128-action library, single correct branch | **362 µs** |
-| 16 redundant paths, picks the cheapest | **24 µs** |
-| Goal already satisfied (fast-path early return) | **6.9 ns** |
-| `Goal::satisfied_by` (1 required fact) | **6.2 ns** |
-| `State::contains` (hit / miss) | **5.4 ns / 2.7 ns** |
-| `Action::applicable` (met / unmet) | **17 ns / 14 ns** |
-| 64 concurrent plans via Rayon over `Arc<Planner>` | **145 µs** (5.4× faster than sequential) |
+| 5-step linear plan | **3.3 µs** |
+| 50-step linear plan | **32 µs** |
+| 128-action library, single correct branch | **337 µs** |
+| 16 redundant paths, picks the cheapest | **23 µs** |
+| Goal already satisfied (fast-path early return) | **7.2 ns** |
+| `Goal::satisfied_by` (1 required fact) | **6.5 ns** |
+| `State::contains` (hit / miss) | **5.1 ns / 2.6 ns** |
+| `Action::applicable` (met / unmet) | **16 ns / 13 ns** |
+| 64 concurrent plans via Rayon over `Arc<Planner>` | **148 µs** (5.2× faster than sequential) |
 
 Canonical summary with full tables and trade-offs: [`docs/performance.md`](docs/performance.md). Raw bench logs accumulate as `docs/bench-<label>.txt`; per-change deltas live in dated `docs/perf-comparison-YYYY-MM-DD.md` snapshots once the suite is touched.
 

--- a/goap-planner/docs/bench-2026-05-02.txt
+++ b/goap-planner/docs/bench-2026-05-02.txt
@@ -1,0 +1,332 @@
+   Compiling proc-macro2 v1.0.106
+   Compiling unicode-ident v1.0.24
+   Compiling quote v1.0.45
+   Compiling crossbeam-utils v0.8.21
+   Compiling serde_core v1.0.228
+   Compiling rayon-core v1.13.0
+   Compiling zerocopy v0.8.48
+   Compiling either v1.15.0
+   Compiling serde v1.0.228
+   Compiling zmij v1.0.21
+   Compiling autocfg v1.5.0
+   Compiling libc v0.2.186
+   Compiling cfg-if v1.0.4
+   Compiling serde_json v1.0.149
+   Compiling memchr v2.8.0
+   Compiling ciborium-io v0.2.2
+   Compiling itoa v1.0.18
+   Compiling regex-syntax v0.8.10
+   Compiling num-traits v0.2.19
+   Compiling plotters-backend v0.3.7
+   Compiling clap_lex v1.1.0
+   Compiling anstyle v1.0.14
+   Compiling clap_builder v4.6.0
+   Compiling plotters-svg v0.3.7
+   Compiling regex-automata v0.4.14
+   Compiling itertools v0.10.5
+   Compiling rustc-hash v2.1.2
+   Compiling cast v0.3.0
+   Compiling same-file v1.0.6
+   Compiling once_cell v1.21.4
+   Compiling criterion-plot v0.5.0
+   Compiling clap v4.6.1
+   Compiling walkdir v2.5.0
+   Compiling anes v0.1.6
+   Compiling regex v1.12.3
+   Compiling oorandom v11.1.5
+   Compiling is-terminal v0.4.17
+   Compiling plotters v0.3.7
+   Compiling crossbeam-epoch v0.9.18
+   Compiling crossbeam-deque v0.8.6
+   Compiling syn v2.0.117
+   Compiling rayon v1.12.0
+   Compiling grafo v0.1.0 (/Users/pepe/Workspace/rust/automata-atelier/grafo)
+   Compiling zerocopy-derive v0.8.48
+   Compiling serde_derive v1.0.228
+   Compiling goap-planner v0.1.0 (/Users/pepe/Workspace/rust/automata-atelier/goap-planner)
+   Compiling tinytemplate v1.2.1
+   Compiling half v2.7.1
+   Compiling ciborium-ll v0.2.2
+   Compiling ciborium v0.2.2
+   Compiling criterion v0.5.1
+    Finished `bench` profile [optimized] target(s) in 9.12s
+     Running benches/performance.rs (target/release/deps/performance-acc5bdbe65046d63)
+Gnuplot not found, using plotters backend
+Benchmarking planning/chain/steps/5
+Benchmarking planning/chain/steps/5: Warming up for 3.0000 s
+Benchmarking planning/chain/steps/5: Collecting 100 samples in estimated 5.0059 s (1.5M iterations)
+Benchmarking planning/chain/steps/5: Analyzing
+planning/chain/steps/5  time:   [3.2546 µs 3.2642 µs 3.2753 µs]
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low severe
+  3 (3.00%) low mild
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+Benchmarking planning/chain/steps/10
+Benchmarking planning/chain/steps/10: Warming up for 3.0000 s
+Benchmarking planning/chain/steps/10: Collecting 100 samples in estimated 5.0266 s (848k iterations)
+Benchmarking planning/chain/steps/10: Analyzing
+planning/chain/steps/10 time:   [5.8613 µs 5.8791 µs 5.8999 µs]
+Found 6 outliers among 100 measurements (6.00%)
+  3 (3.00%) low mild
+  3 (3.00%) high mild
+Benchmarking planning/chain/steps/20
+Benchmarking planning/chain/steps/20: Warming up for 3.0000 s
+Benchmarking planning/chain/steps/20: Collecting 100 samples in estimated 5.0325 s (439k iterations)
+Benchmarking planning/chain/steps/20: Analyzing
+planning/chain/steps/20 time:   [11.386 µs 11.416 µs 11.455 µs]
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) low mild
+  1 (1.00%) high severe
+Benchmarking planning/chain/steps/50
+Benchmarking planning/chain/steps/50: Warming up for 3.0000 s
+Benchmarking planning/chain/steps/50: Collecting 100 samples in estimated 5.0070 s (157k iterations)
+Benchmarking planning/chain/steps/50: Analyzing
+planning/chain/steps/50 time:   [31.846 µs 31.926 µs 32.008 µs]
+Found 5 outliers among 100 measurements (5.00%)
+  2 (2.00%) low mild
+  3 (3.00%) high mild
+
+Benchmarking planning/wide/branches/8
+Benchmarking planning/wide/branches/8: Warming up for 3.0000 s
+Benchmarking planning/wide/branches/8: Collecting 100 samples in estimated 5.0194 s (495k iterations)
+Benchmarking planning/wide/branches/8: Analyzing
+planning/wide/branches/8
+                        time:   [10.073 µs 10.117 µs 10.162 µs]
+Benchmarking planning/wide/branches/32
+Benchmarking planning/wide/branches/32: Warming up for 3.0000 s
+Benchmarking planning/wide/branches/32: Collecting 100 samples in estimated 5.2313 s (111k iterations)
+Benchmarking planning/wide/branches/32: Analyzing
+planning/wide/branches/32
+                        time:   [46.849 µs 47.027 µs 47.205 µs]
+Found 5 outliers among 100 measurements (5.00%)
+  2 (2.00%) low mild
+  3 (3.00%) high mild
+Benchmarking planning/wide/branches/128
+Benchmarking planning/wide/branches/128: Warming up for 3.0000 s
+Benchmarking planning/wide/branches/128: Collecting 100 samples in estimated 5.0959 s (15k iterations)
+Benchmarking planning/wide/branches/128: Analyzing
+planning/wide/branches/128
+                        time:   [336.01 µs 336.93 µs 338.01 µs]
+Found 9 outliers among 100 measurements (9.00%)
+  1 (1.00%) low severe
+  3 (3.00%) low mild
+  2 (2.00%) high mild
+  3 (3.00%) high severe
+Benchmarking planning/wide/branches/512
+Benchmarking planning/wide/branches/512: Warming up for 3.0000 s
+Benchmarking planning/wide/branches/512: Collecting 100 samples in estimated 5.2759 s (1100 iterations)
+Benchmarking planning/wide/branches/512: Analyzing
+planning/wide/branches/512
+                        time:   [4.7715 ms 4.7818 ms 4.7928 ms]
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  2 (2.00%) high severe
+
+Benchmarking planning/redundant_paths/paths/2
+Benchmarking planning/redundant_paths/paths/2: Warming up for 3.0000 s
+Benchmarking planning/redundant_paths/paths/2: Collecting 100 samples in estimated 5.0079 s (1.6M iterations)
+Benchmarking planning/redundant_paths/paths/2: Analyzing
+planning/redundant_paths/paths/2
+                        time:   [3.0965 µs 3.1082 µs 3.1205 µs]
+Benchmarking planning/redundant_paths/paths/4
+Benchmarking planning/redundant_paths/paths/4: Warming up for 3.0000 s
+Benchmarking planning/redundant_paths/paths/4: Collecting 100 samples in estimated 5.0018 s (874k iterations)
+Benchmarking planning/redundant_paths/paths/4: Analyzing
+planning/redundant_paths/paths/4
+                        time:   [5.6199 µs 5.6417 µs 5.6678 µs]
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  3 (3.00%) low mild
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking planning/redundant_paths/paths/8
+Benchmarking planning/redundant_paths/paths/8: Warming up for 3.0000 s
+Benchmarking planning/redundant_paths/paths/8: Collecting 100 samples in estimated 5.0235 s (454k iterations)
+Benchmarking planning/redundant_paths/paths/8: Analyzing
+planning/redundant_paths/paths/8
+                        time:   [10.968 µs 11.022 µs 11.074 µs]
+Benchmarking planning/redundant_paths/paths/16
+Benchmarking planning/redundant_paths/paths/16: Warming up for 3.0000 s
+Benchmarking planning/redundant_paths/paths/16: Collecting 100 samples in estimated 5.0406 s (222k iterations)
+Benchmarking planning/redundant_paths/paths/16: Analyzing
+planning/redundant_paths/paths/16
+                        time:   [22.739 µs 22.861 µs 22.978 µs]
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) low mild
+Benchmarking planning/redundant_paths/paths/32
+Benchmarking planning/redundant_paths/paths/32: Warming up for 3.0000 s
+Benchmarking planning/redundant_paths/paths/32: Collecting 100 samples in estimated 5.1880 s (106k iterations)
+Benchmarking planning/redundant_paths/paths/32: Analyzing
+planning/redundant_paths/paths/32
+                        time:   [49.942 µs 50.239 µs 50.533 µs]
+Found 8 outliers among 100 measurements (8.00%)
+  3 (3.00%) low mild
+  4 (4.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking planning/boundaries/already_satisfied
+Benchmarking planning/boundaries/already_satisfied: Warming up for 3.0000 s
+Benchmarking planning/boundaries/already_satisfied: Collecting 100 samples in estimated 5.0000 s (661M iterations)
+Benchmarking planning/boundaries/already_satisfied: Analyzing
+planning/boundaries/already_satisfied
+                        time:   [7.1462 ns 7.1668 ns 7.1883 ns]
+Found 5 outliers among 100 measurements (5.00%)
+  1 (1.00%) low mild
+  4 (4.00%) high mild
+Benchmarking planning/boundaries/unreachable
+Benchmarking planning/boundaries/unreachable: Warming up for 3.0000 s
+Benchmarking planning/boundaries/unreachable: Collecting 100 samples in estimated 5.0050 s (1.5M iterations)
+Benchmarking planning/boundaries/unreachable: Analyzing
+planning/boundaries/unreachable
+                        time:   [3.4166 µs 3.4263 µs 3.4359 µs]
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) low mild
+  2 (2.00%) high mild
+
+Benchmarking ops/state/contains_hit
+Benchmarking ops/state/contains_hit: Warming up for 3.0000 s
+Benchmarking ops/state/contains_hit: Collecting 100 samples in estimated 5.0000 s (990M iterations)
+Benchmarking ops/state/contains_hit: Analyzing
+ops/state/contains_hit  time:   [5.0643 ns 5.0768 ns 5.0895 ns]
+Found 9 outliers among 100 measurements (9.00%)
+  2 (2.00%) low severe
+  3 (3.00%) low mild
+  4 (4.00%) high mild
+Benchmarking ops/state/contains_miss
+Benchmarking ops/state/contains_miss: Warming up for 3.0000 s
+Benchmarking ops/state/contains_miss: Collecting 100 samples in estimated 5.0000 s (1.9B iterations)
+Benchmarking ops/state/contains_miss: Analyzing
+ops/state/contains_miss time:   [2.5727 ns 2.5780 ns 2.5833 ns]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking ops/state/insert
+Benchmarking ops/state/insert: Warming up for 3.0000 s
+Benchmarking ops/state/insert: Collecting 100 samples in estimated 5.0102 s (1.5M iterations)
+Benchmarking ops/state/insert: Analyzing
+ops/state/insert        time:   [870.87 ns 878.90 ns 886.48 ns]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking ops/state/from_facts/1
+Benchmarking ops/state/from_facts/1: Warming up for 3.0000 s
+Benchmarking ops/state/from_facts/1: Collecting 100 samples in estimated 5.0001 s (157M iterations)
+Benchmarking ops/state/from_facts/1: Analyzing
+ops/state/from_facts/1  time:   [31.563 ns 31.725 ns 31.899 ns]
+Found 9 outliers among 100 measurements (9.00%)
+  5 (5.00%) high mild
+  4 (4.00%) high severe
+Benchmarking ops/state/from_facts/10
+Benchmarking ops/state/from_facts/10: Warming up for 3.0000 s
+Benchmarking ops/state/from_facts/10: Collecting 100 samples in estimated 5.0002 s (24M iterations)
+Benchmarking ops/state/from_facts/10: Analyzing
+ops/state/from_facts/10 time:   [216.51 ns 218.79 ns 221.02 ns]
+Benchmarking ops/state/from_facts/100
+Benchmarking ops/state/from_facts/100: Warming up for 3.0000 s
+Benchmarking ops/state/from_facts/100: Collecting 100 samples in estimated 5.0031 s (2.4M iterations)
+Benchmarking ops/state/from_facts/100: Analyzing
+ops/state/from_facts/100
+                        time:   [2.2012 µs 2.2086 µs 2.2169 µs]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+
+Benchmarking ops/action/applicable_met
+Benchmarking ops/action/applicable_met: Warming up for 3.0000 s
+Benchmarking ops/action/applicable_met: Collecting 100 samples in estimated 5.0000 s (305M iterations)
+Benchmarking ops/action/applicable_met: Analyzing
+ops/action/applicable_met
+                        time:   [16.290 ns 16.447 ns 16.607 ns]
+Benchmarking ops/action/applicable_unmet
+Benchmarking ops/action/applicable_unmet: Warming up for 3.0000 s
+Benchmarking ops/action/applicable_unmet: Collecting 100 samples in estimated 5.0000 s (374M iterations)
+Benchmarking ops/action/applicable_unmet: Analyzing
+ops/action/applicable_unmet
+                        time:   [13.250 ns 13.288 ns 13.325 ns]
+Found 7 outliers among 100 measurements (7.00%)
+  2 (2.00%) low severe
+  4 (4.00%) low mild
+  1 (1.00%) high mild
+Benchmarking ops/action/apply
+Benchmarking ops/action/apply: Warming up for 3.0000 s
+Benchmarking ops/action/apply: Collecting 100 samples in estimated 5.0000 s (40M iterations)
+Benchmarking ops/action/apply: Analyzing
+ops/action/apply        time:   [123.09 ns 123.74 ns 124.38 ns]
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+
+Benchmarking ops/goal/trivial_one_required
+Benchmarking ops/goal/trivial_one_required: Warming up for 3.0000 s
+Benchmarking ops/goal/trivial_one_required: Collecting 100 samples in estimated 5.0000 s (759M iterations)
+Benchmarking ops/goal/trivial_one_required: Analyzing
+ops/goal/trivial_one_required
+                        time:   [6.5080 ns 6.5351 ns 6.5607 ns]
+Found 13 outliers among 100 measurements (13.00%)
+  1 (1.00%) low severe
+  9 (9.00%) low mild
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+Benchmarking ops/goal/compound_10_req_10_forbid
+Benchmarking ops/goal/compound_10_req_10_forbid: Warming up for 3.0000 s
+Benchmarking ops/goal/compound_10_req_10_forbid: Collecting 100 samples in estimated 5.0002 s (62M iterations)
+Benchmarking ops/goal/compound_10_req_10_forbid: Analyzing
+ops/goal/compound_10_req_10_forbid
+                        time:   [78.974 ns 79.324 ns 79.704 ns]
+Found 12 outliers among 100 measurements (12.00%)
+  6 (6.00%) low mild
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+Benchmarking ops/goal/unmet_required
+Benchmarking ops/goal/unmet_required: Warming up for 3.0000 s
+Benchmarking ops/goal/unmet_required: Collecting 100 samples in estimated 5.0000 s (1.4B iterations)
+Benchmarking ops/goal/unmet_required: Analyzing
+ops/goal/unmet_required time:   [3.4716 ns 3.4754 ns 3.4800 ns]
+Found 12 outliers among 100 measurements (12.00%)
+  1 (1.00%) low severe
+  4 (4.00%) low mild
+  2 (2.00%) high mild
+  5 (5.00%) high severe
+
+Benchmarking concurrent_plans/sequential_64
+Benchmarking concurrent_plans/sequential_64: Warming up for 3.0000 s
+Benchmarking concurrent_plans/sequential_64: Collecting 100 samples in estimated 7.6589 s (10k iterations)
+Benchmarking concurrent_plans/sequential_64: Analyzing
+concurrent_plans/sequential_64
+                        time:   [760.79 µs 763.95 µs 767.11 µs]
+Benchmarking concurrent_plans/parallel_64_rayon
+Benchmarking concurrent_plans/parallel_64_rayon: Warming up for 3.0000 s
+Benchmarking concurrent_plans/parallel_64_rayon: Collecting 100 samples in estimated 5.2738 s (35k iterations)
+Benchmarking concurrent_plans/parallel_64_rayon: Analyzing
+concurrent_plans/parallel_64_rayon
+                        time:   [147.72 µs 148.11 µs 148.52 µs]
+Found 8 outliers among 100 measurements (8.00%)
+  4 (4.00%) low mild
+  4 (4.00%) high mild
+Benchmarking concurrent_plans/parallel_rayon/8
+Benchmarking concurrent_plans/parallel_rayon/8: Warming up for 3.0000 s
+Benchmarking concurrent_plans/parallel_rayon/8: Collecting 100 samples in estimated 5.1168 s (96k iterations)
+Benchmarking concurrent_plans/parallel_rayon/8: Analyzing
+concurrent_plans/parallel_rayon/8
+                        time:   [52.970 µs 53.307 µs 53.723 µs]
+Found 8 outliers among 100 measurements (8.00%)
+  3 (3.00%) high mild
+  5 (5.00%) high severe
+Benchmarking concurrent_plans/parallel_rayon/32
+Benchmarking concurrent_plans/parallel_rayon/32: Warming up for 3.0000 s
+Benchmarking concurrent_plans/parallel_rayon/32: Collecting 100 samples in estimated 5.0264 s (50k iterations)
+Benchmarking concurrent_plans/parallel_rayon/32: Analyzing
+concurrent_plans/parallel_rayon/32
+                        time:   [98.126 µs 98.586 µs 99.176 µs]
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low mild
+  4 (4.00%) high mild
+  1 (1.00%) high severe
+Benchmarking concurrent_plans/parallel_rayon/128
+Benchmarking concurrent_plans/parallel_rayon/128: Warming up for 3.0000 s
+Benchmarking concurrent_plans/parallel_rayon/128: Collecting 100 samples in estimated 5.9311 s (25k iterations)
+Benchmarking concurrent_plans/parallel_rayon/128: Analyzing
+concurrent_plans/parallel_rayon/128
+                        time:   [231.47 µs 233.53 µs 236.16 µs]
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low mild
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+

--- a/goap-planner/docs/perf-comparison-2026-05-02.md
+++ b/goap-planner/docs/perf-comparison-2026-05-02.md
@@ -1,0 +1,105 @@
+# Performance comparison — 2026-05-02 (validation re-run)
+
+This is a validation re-run of the goap-planner bench suite against an
+**unchanged library**. The only commits since `bench-baseline.txt` was
+captured (`fb4181b`) are CI-workflow changes — PR #5 (reduced criterion
+sampling for CI), the active PR #6 (CI subset mode), and the bench-gate
+fragility follow-up. Neither affects local benchmark performance: the
+source under `goap-planner/src/` is byte-identical to the baseline
+commit.
+
+## Why capture it
+
+1. **Refresh** the canonical [`performance.md`](./performance.md)
+   numbers so the latest "current state" cited from the README stays
+   recent.
+2. **Document run-to-run variance** on this machine so future regression
+   triage has a reference for what same-source drift looks like — the
+   bench-gate fragility follow-up in `docs/todo.md` will need exactly
+   this kind of empirical noise floor.
+
+## Setup
+
+- **Date:** 2026-05-02
+- **Profile:** release (`cargo bench -p goap-planner --bench performance -- --save-baseline 2026-05-02`)
+- **Criterion settings:** defaults — 3 s warm-up, 5 s measurement, 100 samples
+- **Platform:** macOS Darwin 25.3.0, Rust stable (1.95.0)
+- **Raw log:** [`bench-2026-05-02.txt`](./bench-2026-05-02.txt)
+- **Compared against:** [`bench-baseline.txt`](./bench-baseline.txt) (initial sweep, same date)
+- **Flamegraph:** not captured this round, consistent with the baseline (which has the same gap; tracked as a follow-up in PR #4's commit message).
+
+## Results
+
+All 32 individual benches. Δ is `(new − baseline) / baseline × 100`.
+Negative is faster, positive is slower. Markers: `* ` ≥ 5 % drift,
+`!!` ≥ 10 % drift.
+
+| Bench | Baseline (median) | 2026-05-02 (median) | Δ |
+|---|---:|---:|---:|
+| planning/chain/steps/5 | 3.43 µs | 3.26 µs | -4.8 % |
+|  `* ` planning/chain/steps/10 | 6.19 µs | 5.88 µs | -5.1 % |
+| planning/chain/steps/20 | 11.9 µs | 11.4 µs | -4.1 % |
+| planning/chain/steps/50 | 33.3 µs | 31.9 µs | -4.0 % |
+|  `* ` planning/wide/branches/8 | 10.8 µs | 10.1 µs | -6.1 % |
+|  `* ` planning/wide/branches/32 | 49.7 µs | 47.0 µs | -5.4 % |
+|  `* ` planning/wide/branches/128 | 362 µs | 337 µs | -7.0 % |
+|  `* ` planning/wide/branches/512 | 5.22 ms | 4.78 ms | -8.4 % |
+|  `* ` planning/redundant_paths/paths/2 | 3.29 µs | 3.11 µs | -5.6 % |
+|  `* ` planning/redundant_paths/paths/4 | 6.03 µs | 5.64 µs | -6.5 % |
+|  `* ` planning/redundant_paths/paths/8 | 11.7 µs | 11.0 µs | -5.5 % |
+| planning/redundant_paths/paths/16 | 24.0 µs | 22.9 µs | -4.9 % |
+| planning/redundant_paths/paths/32 | 51.9 µs | 50.2 µs | -3.2 % |
+| planning/boundaries/already_satisfied | 6.87 ns | 7.17 ns | +4.3 % |
+| planning/boundaries/unreachable | 3.53 µs | 3.43 µs | -2.8 % |
+|  `* ` ops/state/contains_hit | 5.35 ns | 5.08 ns | -5.1 % |
+| ops/state/contains_miss | 2.71 ns | 2.58 ns | -4.7 % |
+| ops/state/insert | 905 ns | 879 ns | -2.9 % |
+|  `* ` ops/state/from_facts/1 | 33.4 ns | 31.7 ns | -5.0 % |
+| ops/state/from_facts/10 | 228 ns | 219 ns | -4.0 % |
+| ops/state/from_facts/100 | 2.21 µs | 2.21 µs | -0.1 % |
+| ops/action/applicable_met | 17.3 ns | 16.4 ns | -4.8 % |
+| ops/action/applicable_unmet | 13.8 ns | 13.3 ns | -3.5 % |
+| ops/action/apply | 126 ns | 124 ns | -1.8 % |
+|  `* ` ops/goal/trivial_one_required | 6.21 ns | 6.54 ns | +5.2 % |
+| ops/goal/compound_10_req_10_forbid | 77.1 ns | 79.3 ns | +2.8 % |
+| ops/goal/unmet_required | 3.48 ns | 3.48 ns | -0.0 % |
+| concurrent_plans/sequential_64 | 781 µs | 764 µs | -2.2 % |
+| concurrent_plans/parallel_64_rayon | 145 µs | 148 µs | +1.9 % |
+| concurrent_plans/parallel_rayon/8 | 54.0 µs | 53.3 µs | -1.2 % |
+| concurrent_plans/parallel_rayon/32 | 95.8 µs | 98.6 µs | +2.9 % |
+| concurrent_plans/parallel_rayon/128 | 235 µs | 234 µs | -0.5 % |
+
+## Interpretation
+
+- **Range of drift:** -8.4 % to +5.2 % across 32 benches. No bench
+  crossed ±10 %.
+- **Direction:** 24 of 32 benches measured faster on the 2026-05-02 run,
+  6 slower, 2 unchanged. Skew is mild but consistent — likely better
+  CPU thermal headroom and/or quieter background load on this run.
+- **No bench crossed the CI gate's 10 % threshold.** Confirms the
+  threshold is set wide enough to absorb single-machine run-to-run
+  drift on this hardware. Cross-machine drift (the cache-hit path on
+  shared GitHub runners) is wider — that's the separate fragility
+  noted in `docs/todo.md`.
+- **Largest swings cluster on the planning suite.** The
+  `planning/wide/branches/*` cases shift the most (-5.4 % to -8.4 %),
+  consistent with these being the longest-running benches and therefore
+  most exposed to runtime drift accumulated across the warmup +
+  measurement window.
+
+## Decisions
+
+- **Refresh `performance.md` to the new numbers.** The doc tracks
+  "latest measured" per workspace policy.
+- **No code change, no trade-off.** Source is identical to baseline.
+- **No flamegraph.** Consistent with the baseline's known follow-up.
+- **Add a History row** in `performance.md` so the prior baseline stays
+  visible alongside this run.
+
+## Next benchmark trigger
+
+Per `goap-planner/CLAUDE.md`, the next required bench session is on
+any change to `Planner::plan`, `Action::applicable` / `Action::apply`,
+`State::signature` / `State::contains` / `State::insert`,
+`Goal::satisfied_by`, the BFS bound (`max_states`), or the `grafo`
+dependency. None pending.

--- a/goap-planner/docs/performance.md
+++ b/goap-planner/docs/performance.md
@@ -8,8 +8,9 @@ never here.
 **Last measured:** 2026-05-02 (Criterion 0.5, 100 samples, 3 s warm-up,
 release profile)
 **Library version:** goap-planner 0.1.0
-**Platform:** macOS Darwin 25.3.0, Rust stable
-**Raw log:** [`bench-baseline.txt`](./bench-baseline.txt)
+**Platform:** macOS Darwin 25.3.0, Rust stable (1.95.0)
+**Raw log:** [`bench-2026-05-02.txt`](./bench-2026-05-02.txt) (validation re-run; previous: [`bench-baseline.txt`](./bench-baseline.txt))
+**Comparison:** [`perf-comparison-2026-05-02.md`](./perf-comparison-2026-05-02.md)
 
 `goap-planner` runs forward BFS over reachable states, builds a state-
 transition graph, then delegates the shortest-path search to
@@ -23,16 +24,16 @@ scans); the final Dijkstra is grafo's hot path and inherits its numbers.
 
 | Workload | Result |
 |---|---|
-| 5-step linear plan (chain) | **3.4 µs** |
-| 50-step linear plan (chain) | **33 µs** |
-| 128-action library, single correct branch | **362 µs** |
-| 512-action library, single correct branch | **5.2 ms** |
-| 16 redundant paths, picks the cheapest | **24 µs** |
-| Goal already satisfied (fast-path early return) | **6.9 ns** |
-| `Goal::satisfied_by` with one required fact | **6.2 ns** |
-| `State::contains` (hit / miss) | **5.4 ns / 2.7 ns** |
-| `Action::applicable` (preconditions met / unmet) | **17 ns / 14 ns** |
-| 64 concurrent plans via Rayon over `Arc<Planner>` | **145 µs** (5.4× faster than sequential) |
+| 5-step linear plan (chain) | **3.3 µs** |
+| 50-step linear plan (chain) | **32 µs** |
+| 128-action library, single correct branch | **337 µs** |
+| 512-action library, single correct branch | **4.8 ms** |
+| 16 redundant paths, picks the cheapest | **23 µs** |
+| Goal already satisfied (fast-path early return) | **7.2 ns** |
+| `Goal::satisfied_by` with one required fact | **6.5 ns** |
+| `State::contains` (hit / miss) | **5.1 ns / 2.6 ns** |
+| `Action::applicable` (preconditions met / unmet) | **16 ns / 13 ns** |
+| 64 concurrent plans via Rayon over `Arc<Planner>` | **148 µs** (5.2× faster than sequential) |
 
 ---
 
@@ -43,10 +44,10 @@ space size = plan length.
 
 | Plan length | Time     |
 |------------:|----------|
-|           5 | 3.43 µs  |
-|          10 | 6.19 µs  |
-|          20 | 11.9 µs  |
-|          50 | 33.3 µs  |
+|           5 | 3.26 µs  |
+|          10 | 5.88 µs  |
+|          20 | 11.4 µs  |
+|          50 | 31.9 µs  |
 
 Roughly linear in plan length: per-step cost is dominated by `Action::apply`
 (state clone + effect application) and the final Dijkstra over a chain of
@@ -59,10 +60,10 @@ to the goal. Stresses per-state action-library scan.
 
 | Branches | Total actions | Time     |
 |---------:|--------------:|----------|
-|        8 |            16 | 10.8 µs  |
-|       32 |            64 | 49.7 µs  |
-|      128 |           256 | 362 µs   |
-|      512 |          1024 | 5.22 ms  |
+|        8 |            16 | 10.1 µs  |
+|       32 |            64 | 47.0 µs  |
+|      128 |           256 | 337 µs   |
+|      512 |          1024 | 4.78 ms  |
 
 Cost grows ~quadratically with branch count: state space scales linearly,
 and the per-state action scan also scales linearly. Expect this shape on
@@ -76,11 +77,11 @@ Dijkstra.
 
 | Paths | Time     |
 |------:|----------|
-|     2 | 3.29 µs  |
-|     4 | 6.03 µs  |
-|     8 | 11.7 µs  |
-|    16 | 24.0 µs  |
-|    32 | 51.9 µs  |
+|     2 | 3.11 µs  |
+|     4 | 5.64 µs  |
+|     8 | 11.0 µs  |
+|    16 | 22.9 µs  |
+|    32 | 50.2 µs  |
 
 Linear scaling — `edge_map` insertions and the final Dijkstra both grow
 proportionally with path count.
@@ -89,8 +90,8 @@ proportionally with path count.
 
 | Scenario             | Time     |
 |----------------------|----------|
-| `already_satisfied`  | 6.87 ns  |
-| `unreachable`        | 3.53 µs  |
+| `already_satisfied`  | 7.17 ns  |
+| `unreachable`        | 3.43 µs  |
 
 `already_satisfied` is the fast-path early return at the top of
 `Planner::plan` — no BFS, no graph build, no Dijkstra. It is essentially
@@ -104,11 +105,11 @@ the cost of one `Goal::satisfied_by` call.
 
 | Operation               | Time     |
 |-------------------------|----------|
-| `contains` (hit)        | 5.35 ns  |
-| `contains` (miss)       | 2.71 ns  |
-| `insert`                | 905 ns   |
-| `from_facts(1)`         | 33.4 ns  |
-| `from_facts(10)`        | 228 ns   |
+| `contains` (hit)        | 5.08 ns  |
+| `contains` (miss)       | 2.58 ns  |
+| `insert`                | 879 ns   |
+| `from_facts(1)`         | 31.7 ns  |
+| `from_facts(10)`        | 219 ns   |
 | `from_facts(100)`       | 2.21 µs  |
 
 `contains` is `FxHashSet::contains` — flat O(1). `insert` is dominated by
@@ -119,9 +120,9 @@ input size for the same reason.
 
 | Operation                          | Time     |
 |------------------------------------|----------|
-| `applicable` (preconditions met)   | 17.3 ns  |
-| `applicable` (preconditions unmet) | 13.8 ns  |
-| `apply`                            | 126 ns   |
+| `applicable` (preconditions met)   | 16.4 ns  |
+| `applicable` (preconditions unmet) | 13.3 ns  |
+| `apply`                            | 124 ns   |
 
 `applicable` is `O(|preconditions|)` membership lookups; `apply` clones
 the state then mutates it in place. Most of `apply`'s cost is the
@@ -131,8 +132,8 @@ the state then mutates it in place. Most of `apply`'s cost is the
 
 | Goal shape                   | Time     |
 |------------------------------|----------|
-| 1 required fact              | 6.21 ns  |
-| 10 required + 10 forbidden   | 77.1 ns  |
+| 1 required fact              | 6.54 ns  |
+| 10 required + 10 forbidden   | 79.3 ns  |
 | 1 required, unmet            | 3.48 ns  |
 
 `satisfied_by` short-circuits as soon as a required fact is missing —
@@ -145,13 +146,13 @@ shared `Arc<Planner>`. Workload: 20-step chain plan per call.
 
 | Mode                      | Calls | Time     |
 |---------------------------|------:|----------|
-| Sequential                |    64 | 781 µs   |
-| Rayon `par_iter`          |     8 | 53.5 µs  |
-| Rayon `par_iter`          |    32 | 95.8 µs  |
-| Rayon `par_iter`          |    64 | 145 µs   |
-| Rayon `par_iter`          |   128 | 235 µs   |
+| Sequential                |    64 | 764 µs   |
+| Rayon `par_iter`          |     8 | 53.3 µs  |
+| Rayon `par_iter`          |    32 | 98.6 µs  |
+| Rayon `par_iter`          |    64 | 148 µs   |
+| Rayon `par_iter`          |   128 | 234 µs   |
 
-Rayon delivers **~5.4× wall-clock speedup at 64 parallel calls** — each
+Rayon delivers **~5.2× wall-clock speedup at 64 parallel calls** — each
 plan is independent of the others (no shared mutable state inside
 `Planner::plan`), so throughput scales near-linearly with available cores.
 
@@ -178,6 +179,7 @@ planner past current numbers — neither is a problem until it is.
 
 ## History
 
-| Date       | Document                                          | What changed                                          |
-|------------|---------------------------------------------------|-------------------------------------------------------|
-| 2026-05-02 | [`bench-baseline.txt`](./bench-baseline.txt)      | Initial benchmark sweep: planning, micro-ops, concurrent plans |
+| Date       | Document                                                                 | What changed                                                                                       |
+|------------|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| 2026-05-02 | [`bench-baseline.txt`](./bench-baseline.txt)                             | Initial benchmark sweep: planning, micro-ops, concurrent plans                                     |
+| 2026-05-02 | [`bench-2026-05-02.txt`](./bench-2026-05-02.txt) + [comparison](./perf-comparison-2026-05-02.md) | Validation re-run on identical source. -8.4 % to +5.2 % drift across 32 benches; no real changes. |


### PR DESCRIPTION
## Summary

- Fresh `cargo bench -p goap-planner` run with full local sampling (Criterion defaults: 100 samples, 3 s warm-up, 5 s measurement). Raw log saved as `goap-planner/docs/bench-2026-05-02.txt` so the file accumulates as historical evidence alongside `bench-baseline.txt`.
- Library source is unchanged since the original baseline (`fb4181b`); the only commits in between are CI-workflow changes that don't affect local bench performance. So this is a **validation re-run**, not a perf change.
- Range across 32 benches: **-8.4 % to +5.2 %**, no bench crossed ±10 %. Mild systematic skew toward "faster" — likely better thermal headroom on this run. Interpretation in `goap-planner/docs/perf-comparison-2026-05-02.md`.
- Refreshed `goap-planner/docs/performance.md` (every table + `Last measured` + History row) and the highlight tables in both `README.md` (workspace) and `goap-planner/README.md` to the new numbers — workspace policy is "always reflect the latest measured numbers."
- **No flamegraph this round.** Consistent with the original baseline, which has the same gap (tracked as a follow-up since PR #4's commit message). Worth resolving the next time we have sudo on hand.

## Conventional commit

Type (check one):

- [ ] `feat` — new user-visible capability
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `style` — formatting, whitespace, no behaviour change
- [ ] `refactor` — internal change, no behaviour or interface change
- [ ] `perf` — performance improvement
- [ ] `test` — adding or fixing tests
- [ ] `build` — build system, dependencies, tooling
- [ ] `ci` — CI configuration
- [ ] `chore` — other non-source/non-test changes
- [ ] `revert` — reverts a prior commit

Scope (crate or area, e.g. `grafo`, `goap-planner`, `uncharles`, `ci`, `docs`):

`goap-planner`

## Breaking changes

None.

## Test plan

- [x] `cargo fmt --all` (verified clean via `--check`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — not re-run; this PR is doc-only and the prior session's run was clean
- [x] Manual verification: full `cargo bench -p goap-planner` completed locally, all 32 benches captured. Numbers in `performance.md` and the two READMEs match the medians reported in `bench-2026-05-02.txt`.

## Linked issues

None. The "bench gate fragility" follow-up entry on PR #6 will benefit from this run as a same-machine noise-floor reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)