### PR TITLE
docs(uncharles): articulate body, extend legs, replace clipboard with teapot

### DIFF
--- a/uncharles/assets/banner.svg
+++ b/uncharles/assets/banner.svg
@@ -79,18 +79,32 @@
     <rect x="156" y="122" width="8" height="8" rx="1" fill="#C77F45"/>
   </g>
 
-  <!-- Body / vest -->
-  <rect x="115" y="132" width="90" height="118" rx="6" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
-  <!-- Vest split (vertical centre line) -->
-  <line x1="160" y1="132" x2="160" y2="250" stroke="#1E3A5F" stroke-width="1" stroke-opacity="0.7"/>
-  <!-- Buttons -->
-  <circle cx="160" cy="155" r="2.2" fill="#1E3A5F"/>
-  <circle cx="160" cy="185" r="2.2" fill="#1E3A5F"/>
-  <circle cx="160" cy="215" r="2.2" fill="#1E3A5F"/>
-  <!-- Pocket detail (asymmetric, like a vest welt pocket) -->
+  <!-- Torso (upper body): the vest section, where the bow tie attaches -->
+  <rect x="115" y="132" width="90" height="72" rx="6" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
+  <!-- Vest split (centre seam, torso only) -->
+  <line x1="160" y1="132" x2="160" y2="204" stroke="#1E3A5F" stroke-width="1" stroke-opacity="0.7"/>
+  <!-- Buttons (two, sized to the shorter torso) -->
+  <circle cx="160" cy="152" r="2.2" fill="#1E3A5F"/>
+  <circle cx="160" cy="180" r="2.2" fill="#1E3A5F"/>
+  <!-- Welt pocket on the torso -->
   <line x1="124" y1="170" x2="146" y2="170" stroke="#1E3A5F" stroke-width="1"/>
   <line x1="124" y1="170" x2="124" y2="178" stroke="#1E3A5F" stroke-width="1"/>
   <line x1="146" y1="170" x2="146" y2="178" stroke="#1E3A5F" stroke-width="1"/>
+
+  <!-- Waist articulation: visible joint between torso and pelvis -->
+  <line x1="128" y1="208" x2="192" y2="208" stroke="#1E3A5F" stroke-width="2"/>
+  <circle cx="160" cy="208" r="4" fill="#C77F45" stroke="#1E3A5F" stroke-width="1.2"/>
+  <circle cx="160" cy="208" r="1.5" fill="#1E3A5F"/>
+
+  <!-- Pelvis (lower body): narrower than the torso, the way classic
+       segmented-robot icons articulate the hip -->
+  <rect x="128" y="212" width="64" height="38" rx="5" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
+  <!-- Belt across the top of the pelvis -->
+  <line x1="128" y1="222" x2="192" y2="222" stroke="#C77F45" stroke-width="1.5"/>
+  <!-- Indicator panel on the pelvis (two small status lights) -->
+  <rect x="148" y="232" width="24" height="9" rx="1.5" fill="none" stroke="#1E3A5F" stroke-width="1"/>
+  <circle cx="155" cy="236.5" r="1.4" fill="#C77F45"/>
+  <circle cx="165" cy="236.5" r="1.4" fill="#1E3A5F"/>
 
   <!-- Left arm of figure (viewer's left): hangs at side -->
   <g stroke="#1E3A5F" stroke-width="2.5" stroke-linecap="round" fill="none">

--- a/uncharles/assets/banner.svg
+++ b/uncharles/assets/banner.svg
@@ -28,134 +28,136 @@
 
   <!-- ============================================================
        UNCHARLES — the valet robot.
-       Tall, slender, formal posture. Bow tie + vest, single-slit
-       visor with two amber eye lights, holding a YAML clipboard
-       in his left hand (viewer's right) at chest level.
-       Bounding box ≈ x:60-280, y:30-285.
+       Redrawn against the Service Model book cover: tall and slender
+       with humanoid proportions, segmented body, and the iconic
+       teapot raised in the right hand (his trademark service pose).
+       Bounding box ≈ x:60-280, y:22-290.
        ============================================================ -->
 
   <!-- Antenna -->
-  <line x1="160" y1="32" x2="160" y2="48" stroke="#1E3A5F" stroke-width="2"/>
-  <circle cx="160" cy="28" r="4" fill="#C77F45" stroke="#1E3A5F" stroke-width="1"/>
+  <line x1="160" y1="30" x2="160" y2="44" stroke="#1E3A5F" stroke-width="2"/>
+  <circle cx="160" cy="26" r="4" fill="#C77F45" stroke="#1E3A5F" stroke-width="1"/>
 
-  <!-- Head: rounded rectangle, in the classic friendly-robot-icon style —
-       boxy enough to read as mechanical, with the corners rounded just
-       enough to feel approachable. -->
-  <rect x="120" y="48" width="80" height="64" rx="10" fill="#FAF6E9" stroke="#1E3A5F" stroke-width="2.5"/>
+  <!-- Head: rounded rectangle in the friendly-robot-icon style. -->
+  <rect x="124" y="44" width="72" height="48" rx="9" fill="#FAF6E9" stroke="#1E3A5F" stroke-width="2.5"/>
 
-  <!-- Audio "ears" / antenna ports on the sides (the bolted bits on
-       classic icon robots) -->
-  <rect x="112" y="68" width="8" height="22" rx="2" fill="#1E3A5F"/>
-  <rect x="200" y="68" width="8" height="22" rx="2" fill="#1E3A5F"/>
-  <circle cx="116" cy="79" r="1.4" fill="#C77F45"/>
-  <circle cx="204" cy="79" r="1.4" fill="#C77F45"/>
+  <!-- Audio "ears" / antenna ports on the sides -->
+  <rect x="116" y="58" width="8" height="20" rx="2" fill="#1E3A5F"/>
+  <rect x="196" y="58" width="8" height="20" rx="2" fill="#1E3A5F"/>
+  <circle cx="120" cy="68" r="1.3" fill="#C77F45"/>
+  <circle cx="200" cy="68" r="1.3" fill="#C77F45"/>
 
-  <!-- Eyes: simple solid dots in the iconic-robot style — two big lit
-       eyes, no human sclera/iris/pupil. A small parchment highlight
-       per eye gives them a tiny bit of life. -->
-  <circle cx="146" cy="74" r="6.5" fill="#1E3A5F"/>
-  <circle cx="174" cy="74" r="6.5" fill="#1E3A5F"/>
-  <circle cx="146" cy="74" r="3.5" fill="#C77F45"/>
-  <circle cx="174" cy="74" r="3.5" fill="#C77F45"/>
-  <circle cx="147.5" cy="72.5" r="1" fill="#FAF6E9"/>
-  <circle cx="175.5" cy="72.5" r="1" fill="#FAF6E9"/>
+  <!-- Eyes -->
+  <circle cx="148" cy="64" r="5.5" fill="#1E3A5F"/>
+  <circle cx="172" cy="64" r="5.5" fill="#1E3A5F"/>
+  <circle cx="148" cy="64" r="3"   fill="#C77F45"/>
+  <circle cx="172" cy="64" r="3"   fill="#C77F45"/>
+  <circle cx="149.2" cy="62.8" r="0.9" fill="#FAF6E9"/>
+  <circle cx="173.2" cy="62.8" r="0.9" fill="#FAF6E9"/>
 
-  <!-- Mouth: a small friendly smile — just a curved line, no grille. -->
-  <path d="M 148 96 Q 160 104 172 96" fill="none" stroke="#1E3A5F" stroke-width="2" stroke-linecap="round"/>
+  <!-- Friendly smile -->
+  <path d="M 150 80 Q 160 86 170 80" fill="none" stroke="#1E3A5F" stroke-width="1.8" stroke-linecap="round"/>
 
-  <!-- Bolts at the corners of the face plate (icon-robot detail) -->
-  <circle cx="127" cy="55" r="1.4" fill="#1E3A5F"/>
-  <circle cx="193" cy="55" r="1.4" fill="#1E3A5F"/>
-  <circle cx="127" cy="105" r="1.4" fill="#1E3A5F"/>
-  <circle cx="193" cy="105" r="1.4" fill="#1E3A5F"/>
+  <!-- Bolts at the face-plate corners -->
+  <circle cx="130" cy="50" r="1.3" fill="#1E3A5F"/>
+  <circle cx="190" cy="50" r="1.3" fill="#1E3A5F"/>
+  <circle cx="130" cy="86" r="1.3" fill="#1E3A5F"/>
+  <circle cx="190" cy="86" r="1.3" fill="#1E3A5F"/>
 
   <!-- Neck -->
-  <line x1="160" y1="112" x2="160" y2="120" stroke="#1E3A5F" stroke-width="2"/>
+  <line x1="160" y1="92" x2="160" y2="100" stroke="#1E3A5F" stroke-width="2"/>
 
-  <!-- Bow tie (the defining valet detail) -->
+  <!-- Bow tie (the valet detail) -->
   <g stroke="#1E3A5F" stroke-width="1" stroke-linejoin="round">
-    <path d="M155 118 L142 125 L142 134 L155 127 Z" fill="#C77F45"/>
-    <path d="M165 118 L178 125 L178 134 L165 127 Z" fill="#C77F45"/>
-    <rect x="156" y="122" width="8" height="8" rx="1" fill="#C77F45"/>
+    <path d="M155 98 L142 105 L142 114 L155 107 Z" fill="#C77F45"/>
+    <path d="M165 98 L178 105 L178 114 L165 107 Z" fill="#C77F45"/>
+    <rect x="156" y="102" width="8" height="8" rx="1" fill="#C77F45"/>
   </g>
 
-  <!-- Torso (upper body): the vest section, where the bow tie attaches -->
-  <rect x="115" y="132" width="90" height="72" rx="6" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
-  <!-- Vest split (centre seam, torso only) -->
-  <line x1="160" y1="132" x2="160" y2="204" stroke="#1E3A5F" stroke-width="1" stroke-opacity="0.7"/>
-  <!-- Buttons (two, sized to the shorter torso) -->
+  <!-- Torso (upper body): vest, buttons, pocket -->
+  <rect x="120" y="112" width="80" height="60" rx="6" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
+  <line x1="160" y1="112" x2="160" y2="172" stroke="#1E3A5F" stroke-width="1" stroke-opacity="0.7"/>
+  <circle cx="160" cy="128" r="2.2" fill="#1E3A5F"/>
   <circle cx="160" cy="152" r="2.2" fill="#1E3A5F"/>
-  <circle cx="160" cy="180" r="2.2" fill="#1E3A5F"/>
-  <!-- Welt pocket on the torso -->
-  <line x1="124" y1="170" x2="146" y2="170" stroke="#1E3A5F" stroke-width="1"/>
-  <line x1="124" y1="170" x2="124" y2="178" stroke="#1E3A5F" stroke-width="1"/>
-  <line x1="146" y1="170" x2="146" y2="178" stroke="#1E3A5F" stroke-width="1"/>
+  <line x1="128" y1="142" x2="148" y2="142" stroke="#1E3A5F" stroke-width="1"/>
+  <line x1="128" y1="142" x2="128" y2="150" stroke="#1E3A5F" stroke-width="1"/>
+  <line x1="148" y1="142" x2="148" y2="150" stroke="#1E3A5F" stroke-width="1"/>
 
-  <!-- Waist articulation: visible joint between torso and pelvis -->
-  <line x1="128" y1="208" x2="192" y2="208" stroke="#1E3A5F" stroke-width="2"/>
-  <circle cx="160" cy="208" r="4" fill="#C77F45" stroke="#1E3A5F" stroke-width="1.2"/>
-  <circle cx="160" cy="208" r="1.5" fill="#1E3A5F"/>
+  <!-- Waist articulation joint -->
+  <line x1="132" y1="176" x2="188" y2="176" stroke="#1E3A5F" stroke-width="2"/>
+  <circle cx="160" cy="176" r="4" fill="#C77F45" stroke="#1E3A5F" stroke-width="1.2"/>
+  <circle cx="160" cy="176" r="1.5" fill="#1E3A5F"/>
 
-  <!-- Pelvis (lower body): narrower than the torso, the way classic
-       segmented-robot icons articulate the hip -->
-  <rect x="128" y="212" width="64" height="38" rx="5" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
-  <!-- Belt across the top of the pelvis -->
-  <line x1="128" y1="222" x2="192" y2="222" stroke="#C77F45" stroke-width="1.5"/>
-  <!-- Indicator panel on the pelvis (two small status lights) -->
-  <rect x="148" y="232" width="24" height="9" rx="1.5" fill="none" stroke="#1E3A5F" stroke-width="1"/>
-  <circle cx="155" cy="236.5" r="1.4" fill="#C77F45"/>
-  <circle cx="165" cy="236.5" r="1.4" fill="#1E3A5F"/>
+  <!-- Pelvis (narrower lower segment) -->
+  <rect x="132" y="180" width="56" height="28" rx="5" fill="none" stroke="#1E3A5F" stroke-width="2.5"/>
+  <line x1="132" y1="188" x2="188" y2="188" stroke="#C77F45" stroke-width="1.5"/>
+  <rect x="148" y="195" width="24" height="9" rx="1.5" fill="none" stroke="#1E3A5F" stroke-width="1"/>
+  <circle cx="155" cy="199.5" r="1.4" fill="#C77F45"/>
+  <circle cx="165" cy="199.5" r="1.4" fill="#1E3A5F"/>
 
-  <!-- Left arm of figure (viewer's left): hangs at side -->
+  <!-- Right arm of figure (viewer's left): hangs at side, full length now -->
   <g stroke="#1E3A5F" stroke-width="2.5" stroke-linecap="round" fill="none">
-    <line x1="115" y1="142" x2="98" y2="180"/>
-    <line x1="98" y1="180" x2="98" y2="222"/>
+    <line x1="120" y1="120" x2="105" y2="155"/>
+    <line x1="105" y1="155" x2="105" y2="200"/>
   </g>
-  <circle cx="98" cy="228" r="6" fill="#1E3A5F" stroke="none"/>
+  <circle cx="105" cy="206" r="5.5" fill="#1E3A5F"/>
 
-  <!-- Right arm of figure (viewer's right): bent forward, holding clipboard -->
+  <!-- Left arm of figure (viewer's right): RAISED, holding the teapot —
+       the iconic Service Model pose from the book cover -->
   <g stroke="#1E3A5F" stroke-width="2.5" stroke-linecap="round" fill="none">
-    <line x1="205" y1="142" x2="222" y2="178"/>
-    <line x1="222" y1="178" x2="232" y2="200"/>
+    <!-- Upper arm: shoulder up and out -->
+    <line x1="200" y1="120" x2="222" y2="98"/>
+    <!-- Forearm: bent up, presenting the teapot -->
+    <line x1="222" y1="98" x2="232" y2="68"/>
   </g>
-  <circle cx="234" cy="206" r="6" fill="#1E3A5F" stroke="none"/>
+  <!-- Hand grip on the teapot handle -->
+  <circle cx="232" cy="68" r="4" fill="#1E3A5F"/>
 
-  <!-- Clipboard with YAML hint (held in front of the body) -->
-  <g transform="translate(208,168)">
-    <!-- Clipboard backing -->
-    <rect x="0" y="0" width="48" height="62" rx="2" fill="#FAF6E9" stroke="#1E3A5F" stroke-width="1.5"/>
-    <!-- Clip at top -->
-    <rect x="17" y="-4" width="14" height="7" rx="1" fill="#C77F45" stroke="#1E3A5F" stroke-width="1"/>
-    <!-- YAML-flavoured text lines: copper for keys, muted for values -->
-    <line x1="6"  y1="13" x2="22" y2="13" stroke="#C77F45" stroke-width="1"/>
-    <line x1="24" y1="13" x2="42" y2="13" stroke="#7B6B47" stroke-width="0.8" stroke-opacity="0.7"/>
-    <line x1="10" y1="22" x2="22" y2="22" stroke="#C77F45" stroke-width="1"/>
-    <line x1="24" y1="22" x2="40" y2="22" stroke="#7B6B47" stroke-width="0.8" stroke-opacity="0.7"/>
-    <line x1="10" y1="31" x2="20" y2="31" stroke="#C77F45" stroke-width="1"/>
-    <line x1="22" y1="31" x2="38" y2="31" stroke="#7B6B47" stroke-width="0.8" stroke-opacity="0.7"/>
-    <line x1="6"  y1="42" x2="22" y2="42" stroke="#C77F45" stroke-width="1"/>
-    <line x1="24" y1="42" x2="42" y2="42" stroke="#7B6B47" stroke-width="0.8" stroke-opacity="0.7"/>
-    <line x1="10" y1="51" x2="22" y2="51" stroke="#C77F45" stroke-width="1"/>
-    <line x1="24" y1="51" x2="36" y2="51" stroke="#7B6B47" stroke-width="0.8" stroke-opacity="0.7"/>
+  <!-- Teapot — Uncharles's emblematic prop. Held aloft, spout pointing
+       out and away from the body, lid centred, gentle wisp of steam. -->
+  <g transform="translate(252,62)" stroke="#1E3A5F" stroke-width="1.4" stroke-linejoin="round" stroke-linecap="round">
+    <!-- Pot body: rounded vessel -->
+    <path d="M -16 -2
+             Q -18 8  -10 11
+             L 10 11
+             Q 18 8  16 -2
+             Q 18 -8  10 -8
+             L -10 -8
+             Q -18 -8  -16 -2 Z"
+          fill="#FAF6E9"/>
+    <!-- Spout, pointing right and slightly up -->
+    <path d="M 14 -3 L 26 -8 L 24 -3 Q 22 -1  16 0 Z"
+          fill="#FAF6E9"/>
+    <!-- Handle on the left -->
+    <path d="M -16 -3 Q -26 -2  -24 6 Q -20 12  -14 8" fill="none"/>
+    <!-- Lid -->
+    <path d="M -5 -8 L -7 -12 L 7 -12 L 5 -8 Z" fill="#FAF6E9"/>
+    <!-- Lid knob -->
+    <circle cx="0" cy="-13.5" r="1.6" fill="#C77F45" stroke="#1E3A5F" stroke-width="1"/>
+    <!-- Decorative band around the body -->
+    <line x1="-14" y1="3" x2="14" y2="3" stroke="#C77F45" stroke-width="0.8"/>
   </g>
-  <!-- Filename annotation under the clipboard -->
-  <text x="232" y="246" text-anchor="middle"
-        font-family="'Courier New', monospace" font-size="9" fill="#7B6B47" font-style="italic">config.yaml</text>
+  <!-- Steam wisps rising from the lid -->
+  <g stroke="#1E3A5F" stroke-width="1" stroke-linecap="round" fill="none" stroke-opacity="0.55">
+    <path d="M 248 44 Q 250 39  248 34 Q 246 29  248 24"/>
+    <path d="M 256 42 Q 258 37  256 32 Q 254 27  256 22"/>
+  </g>
 
-  <!-- Legs -->
+  <!-- Legs (long, humanoid proportions) -->
   <g stroke="#1E3A5F" stroke-linecap="round" stroke-linejoin="round" fill="none">
-    <line x1="142" y1="250" x2="142" y2="278" stroke-width="3"/>
-    <line x1="178" y1="250" x2="178" y2="278" stroke-width="3"/>
-    <line x1="132" y1="282" x2="155" y2="282" stroke-width="3.5"/>
-    <line x1="166" y1="282" x2="188" y2="282" stroke-width="3.5"/>
+    <line x1="146" y1="208" x2="146" y2="278" stroke-width="3"/>
+    <line x1="174" y1="208" x2="174" y2="278" stroke-width="3"/>
   </g>
+  <!-- Feet: small filled blocks instead of thin lines -->
+  <rect x="132" y="278" width="28" height="7" rx="2" fill="#1E3A5F"/>
+  <rect x="160" y="278" width="28" height="7" rx="2" fill="#1E3A5F"/>
 
   <!-- Tiny dimension annotation, like a technical drawing -->
   <g stroke="#1E3A5F" stroke-width="0.5" stroke-opacity="0.45" fill="#1E3A5F" fill-opacity="0.55"
      font-family="'Courier New', monospace" font-size="8">
-    <line x1="46" y1="48" x2="46" y2="282"/>
-    <line x1="42" y1="48" x2="50" y2="48"/>
-    <line x1="42" y1="282" x2="50" y2="282"/>
+    <line x1="46" y1="44" x2="46" y2="285"/>
+    <line x1="42" y1="44" x2="50" y2="44"/>
+    <line x1="42" y1="285" x2="50" y2="285"/>
     <text x="34" y="170" transform="rotate(-90,34,170)">CHARLES-class</text>
   </g>
 


### PR DESCRIPTION
## Summary

Two-step refactor of the Uncharles figure on the banner, in response to feedback that the body felt monolithic and the proportions weren't humanoid:

1. **Articulate the body** (commit 1) — the old single 90×118 slab becomes a torso (vest section) plus a narrower pelvis, connected by a visible copper waist disc. Pelvis carries a belt and a small two-LED indicator panel.

2. **Redraw against the *Service Model* book cover** (commit 2) — the previous figure was stocky (legs only ~12% of body) and held a YAML clipboard, neither of which matches Uncharles in the book. Redraw with humanoid proportions (legs+feet ~29% of figure), slimmer overall (torso 80×60, pelvis 56×28, head 72×48), and replace the clipboard with the **iconic teapot** raised in his right hand — the trademark Service Model pose. Other arm hangs at his side. Steam wisps drift up off the lid.

All other figure details — rounded-rectangle head with the iconic-robot face, bow tie, vest with buttons + welt pocket, articulated waist joint, side dimension annotation — are preserved through both commits.

## Conventional commit

Type (check one):

- [ ] `feat`
- [ ] `fix`
- [x] `docs` — documentation/asset only
- [ ] `style`
- [ ] `refactor`
- [ ] `perf`
- [ ] `test`
- [ ] `build`
- [ ] `ci`
- [ ] `chore`
- [ ] `revert`

Scope: `uncharles`

## Breaking changes

None.

## Test plan

- [x] SVG validates as well-formed XML (`xmllint --noout`)
- [x] Rendered preview via `qlmanage -t` looks as intended (humanoid silhouette, teapot clearly readable, friendly face, all body segments visible)
- [x] No code changed; `cargo` checks not re-run

## Linked issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)