### PR TITLE
feat(uncharles): auto-install pendrive scan tools via brew on macOS

### DIFF
--- a/uncharles/configs/pendrive_audit.yaml
+++ b/uncharles/configs/pendrive_audit.yaml
@@ -15,10 +15,14 @@
 #
 #   brew install fswatch gitleaks trufflehog bulk_extractor
 #
-# Each tool is detected at exec time; missing tools degrade gracefully
-# (start_copy_monitor falls back to a marker, scan_secrets falls back
-# to grep, scan_pii records "skipped"). The planner advances either
-# way, so the config is runnable on a stock machine.
+# On macOS with brew, the planner does this for you: the
+# `install_tools` action detects missing tools and runs
+# `brew install` for whatever's absent. On other systems (Linux, or
+# macOS without brew) the action no-ops and missing tools degrade
+# gracefully — start_copy_monitor falls back to a marker,
+# scan_secrets falls back to grep, scan_pii records "skipped". The
+# planner advances either way, so the config is runnable on a stock
+# machine even with no network.
 #
 # === Real-pendrive run ===
 #
@@ -38,6 +42,7 @@
 #
 # === Audit artifacts under /tmp/uncharles-audit/ ===
 #
+#   install-tools.log           output of the auto-install attempt
 #   file-map.txt                sha256 + path of every file on the mount
 #   secrets.txt                 human-readable secrets summary
 #   secrets-gitleaks.json       gitleaks raw findings (when installed)
@@ -62,6 +67,13 @@ sensors:
   # Per-step progress markers. These are file-existence sensors so the
   # planner sees real progress between iterations rather than just
   # trusting the optimistic effects.
+  # Auto-install attempted this session. The action always succeeds
+  # (logging its decision regardless of OS / brew presence / tool
+  # availability), and the marker is the action's log file. Cleared on
+  # eject so reinsertion re-checks tool availability.
+  - name: tools_install_attempted
+    cmd: ["test", "-f", "/tmp/uncharles-audit/install-tools.log"]
+
   - name: map_recorded
     cmd: ["test", "-f", "/tmp/uncharles-audit/file-map.txt"]
 
@@ -88,7 +100,7 @@ sensors:
         if [ -n "${PENDRIVE_MOUNT:-}" ] && [ -d "$PENDRIVE_MOUNT" ]; then
           exit 1
         fi
-        for f in monitor.pid sealed.txt file-map.txt secrets.txt pii.txt; do
+        for f in monitor.pid sealed.txt file-map.txt secrets.txt pii.txt install-tools.log; do
           [ -f "/tmp/uncharles-audit/$f" ] && exit 0
         done
         exit 1
@@ -103,7 +115,7 @@ sensors:
       - -c
       - |
         if [ -z "${PENDRIVE_MOUNT:-}" ] || [ ! -d "$PENDRIVE_MOUNT" ]; then
-          for f in monitor.pid sealed.txt file-map.txt secrets.txt pii.txt; do
+          for f in monitor.pid sealed.txt file-map.txt secrets.txt pii.txt install-tools.log; do
             [ -f "/tmp/uncharles-audit/$f" ] && exit 1
           done
           exit 0
@@ -111,6 +123,69 @@ sensors:
         [ -f /tmp/uncharles-audit/sealed.txt ]
 
 actions:
+  # Bring the toolchain up before scanning. Detects OS, checks brew
+  # availability, computes the missing-tool set, and runs `brew
+  # install` for whatever's absent — but only on Darwin/macOS with
+  # brew on PATH. On unsupported environments (Linux, no brew, etc.)
+  # the action logs its reason for skipping and exits cleanly so the
+  # graceful-degradation paths in the scan actions still run.
+  #
+  # The action always exits 0 — install failure is non-fatal because
+  # scan_secrets and scan_pii fall back to grep/skipped when their
+  # underlying tool is missing. Cost is high (5.0) so the planner
+  # never picks this when the marker is already set; combined with
+  # the marker-file sensor, it runs at most once per audit session.
+  - name: install_tools
+    cost: 5.0
+    requires: [pendrive_mounted]
+    adds: [tools_install_attempted]
+    cmd:
+      - sh
+      - -c
+      - |
+        mkdir -p /tmp/uncharles-audit
+        log=/tmp/uncharles-audit/install-tools.log
+        : > "$log"
+
+        os=$(uname -s)
+        echo "[install_tools] OS=$os" >> "$log"
+        if [ "$os" != "Darwin" ]; then
+          echo "[install_tools] only Darwin/macOS auto-install is supported" >> "$log"
+          echo "[install_tools] missing tools (if any) will degrade gracefully in scans" >> "$log"
+          exit 0
+        fi
+
+        if ! command -v brew >/dev/null 2>&1; then
+          echo "[install_tools] brew not on PATH; cannot auto-install" >> "$log"
+          echo "[install_tools] install Homebrew from https://brew.sh, or rely on graceful fallbacks" >> "$log"
+          exit 0
+        fi
+
+        missing=""
+        for t in fswatch gitleaks trufflehog bulk_extractor; do
+          if ! command -v "$t" >/dev/null 2>&1; then
+            missing="$missing $t"
+          fi
+        done
+
+        if [ -z "$missing" ]; then
+          echo "[install_tools] all tools present, nothing to install" >> "$log"
+          exit 0
+        fi
+
+        echo "[install_tools] missing:$missing" >> "$log"
+        echo "[install_tools] running: brew install$missing" >> "$log"
+        brew install $missing >> "$log" 2>&1 || true
+
+        echo "[install_tools] post-install state:" >> "$log"
+        for t in fswatch gitleaks trufflehog bulk_extractor; do
+          if command -v "$t" >/dev/null 2>&1; then
+            echo "  $t: present" >> "$log"
+          else
+            echo "  $t: still missing" >> "$log"
+          fi
+        done
+
   # Hash every file on the drive. macOS `shasum -a 256` is built-in.
   # Skips macOS metadata directories (.fseventsd, .Spotlight-V100, .Trashes).
   - name: enumerate_files
@@ -140,7 +215,7 @@ actions:
   # raw JSON outputs sit alongside for deeper inspection.
   - name: scan_secrets
     cost: 3.0
-    requires: [pendrive_mounted, map_recorded]
+    requires: [pendrive_mounted, map_recorded, tools_install_attempted]
     adds: [secrets_scanned]
     cmd:
       - sh
@@ -199,7 +274,7 @@ actions:
   # credentials." Skipped gracefully when bulk_extractor isn't installed.
   - name: scan_pii
     cost: 3.0
-    requires: [pendrive_mounted, map_recorded]
+    requires: [pendrive_mounted, map_recorded, tools_install_attempted]
     adds: [pii_scanned]
     cmd:
       - sh
@@ -283,7 +358,7 @@ actions:
     cost: 1.0
     requires: [eject_pending]
     adds: [idle]
-    removes: [monitor_active, map_recorded, secrets_scanned, pii_scanned, audit_sealed]
+    removes: [monitor_active, map_recorded, secrets_scanned, pii_scanned, tools_install_attempted, audit_sealed]
     cmd:
       - sh
       - -c
@@ -306,7 +381,8 @@ actions:
               /tmp/uncharles-audit/secrets.txt \
               /tmp/uncharles-audit/secrets-gitleaks.json \
               /tmp/uncharles-audit/secrets-trufflehog.ndjson \
-              /tmp/uncharles-audit/pii.txt
+              /tmp/uncharles-audit/pii.txt \
+              /tmp/uncharles-audit/install-tools.log
         rm -rf /tmp/uncharles-audit/bulk_extractor
 
 goal:


### PR DESCRIPTION
## Summary

- New `install_tools` action runs at session start and brings the toolchain up before scans: detects OS via `uname -s`, checks `brew` availability, computes the missing-tool set across `fswatch / gitleaks / trufflehog / bulk_extractor`, and runs `brew install <missing>` for whatever's absent.
- New sensor `tools_install_attempted` (file-existence on the action's log file) gates `scan_secrets` and `scan_pii`, so the planner orders `install_tools` ahead of them. Action always exits 0 — install failure is non-fatal because the scan actions handle missing tools themselves.
- On non-Darwin or no-brew systems the action logs its decision and exits cleanly, so graceful degradation in `scan_secrets` / `scan_pii` (grep fallback, "skipped" markers) still runs. The config is runnable on Linux / no-brew / no-network with no breakage.

## Conventional commit

Type (check one):

- [x] `feat` — new user-visible capability

Scope: `uncharles`

## Breaking changes

None. Existing mock/real run commands unchanged. Goal model gains one predicate (`tools_install_attempted`) and two preconditions; cleanup_after_eject extended to wipe the new artifact (`install-tools.log`).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] **Schema parse** via `--dry-run --pretty`: 9 sensors, 7 actions, goal `{requires:[idle]}`.
- [x] **Mock-mode end-to-end** (`PENDRIVE_MOUNT=/tmp/fake-pendrive`):
  - Plan: `start_copy_monitor → enumerate_files → install_tools → scan_pii → scan_secrets → seal_audit` (7 iterations, was 6 before).
  - Fast-path log on a fully-equipped machine: `OS=Darwin / all tools present, nothing to install`.
  - Eject → `cleanup_after_eject` wipes `install-tools.log`; reinsert re-runs the full plan including `install_tools`.

## Notes for reviewers

- Stacked on #12 (this branch is based on `feat/pendrive-pro-tools`). Merge order: #12 first, then this.
- Linux package-manager support is deliberately out of scope — the action documents the limitation in its log line and falls through to the graceful path. Adding apt/dnf/pacman would mean either a much more complex action body or a broader OS-abstraction layer; happy to do either as a follow-up if there's demand.
- One known edge: if a user manually `brew uninstall`s a tool *during* a session (unlikely), the marker stays set and that session won't reinstall it. Re-checked on next eject/reinsert. The "always re-check" alternative was rejected because it makes every cycle an unconditional brew query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)