### PR TITLE
feat(uncharles): add inspect subcommand for visualising configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ The crates have deliberately clean separation; preserve it when adding code:
 
 If a change feels like it should live in a lower layer, that's almost always the wrong direction — push it up, not down.
 
+## Performance is important
+
+Whenever changes are made to the core crates grafo and goap-planner performance tests will be executed in the CICD. Make sure after changes and git push, to verify if the benchmark jobs failed, if so analyse and fix the performance issues.
+
 ## Working with git and GitHub
 
 ### Commits and pull requests

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -7,6 +7,20 @@ Read this file before writing or modifying code anywhere in the workspace. The
 sibling `CLAUDE.md` in this directory is just an index — the substantive rules
 live here.
 
+## Quick reference
+
+Use this checklist for every change before considering it done:
+
+- [ ] Tests added/updated proportional to the change (see [Tests](#tests)).
+- [ ] User-facing interfaces have **doctests** and **integration tests** (see [Doctests](#doctests-on-user-exposed-interfaces) and [Integration tests](#integration-tests-for-user-exposed-interfaces)).
+- [ ] Performance-sensitive code follows [Performance and concurrency](#performance-and-concurrency).
+- [ ] I/O-bound network code is `async`; CPU-bound parallel-safe iteration uses `rayon` (see [Async vs Rayon](#async-vs-rayon-decision-rule)).
+- [ ] Any benchmark, perf measurement, or perf-critical demo runs under `--release` (see [Always build `--release` for perf work](#always-build---release-for-perf-work)).
+- [ ] CLI changes follow [CLI conventions](#cli-conventions-posix--kubectl).
+- [ ] Docs updated in the same commit (see [Documentation](#documentation)).
+- [ ] `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --workspace` all pass clean.
+- [ ] Commit message and PR title follow [Conventional Commits](#commits-and-pull-requests).
+
 ## Tests
 
 Every behaviour change ships with tests. Do not mark work done without coverage proportional to the change.
@@ -23,11 +37,154 @@ Where tests live, by crate:
 
 Aim for the highest *meaningful* coverage — every public path, every error variant, every documented behaviour. Avoid coverage theatre: tests that execute code without asserting anything useful are noise, not signal.
 
+### Doctests on user-exposed interfaces
+
+Every **user-exposed interface** ships a docstring with at least one **doctest** that compiles and asserts behaviour. Doctests are the contract the user reads; if it doesn't run, it lies.
+
+A "user-exposed interface" is anything reachable from outside the crate boundary or from an external operator:
+
+- All `pub` items in a library crate (`grafo`, `goap-planner`).
+- CLI subcommands, flags, and exit-code semantics in `uncharles`.
+- HTTP/gRPC handlers, request/response types, and any future network surface.
+- YAML/config schema types deserialised from user input.
+
+Rules:
+
+- Every `pub fn`, `pub struct`, `pub enum`, `pub trait`, and `pub mod` has a `///` summary line, a description if non-obvious, and a `# Examples` section with a runnable doctest.
+- Document `# Errors`, `# Panics`, and `# Safety` whenever they apply. If a function can panic, say when. If it returns `Result`, list the error variants and what triggers each.
+- Doctests must `assert!` / `assert_eq!` something meaningful. A doctest that only constructs a value and never asserts is documentation, not a test.
+- Hide setup noise behind `#` lines so the rendered example reads naturally:
+
+  ```/dev/null/example.rs#L1-10
+  /// Adds two numbers.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// # use mycrate::add;
+  /// assert_eq!(add(2, 3), 5);
+  /// ```
+  pub fn add(a: i32, b: i32) -> i32 { a + b }
+  ```
+
+- For CLI binaries (`uncharles`), put usage examples in the binary's `//!` module docs (`src/main.rs`) and in `--help` output (clap derive docs). Doctests in binary crates are limited; back them with [integration tests](#integration-tests-for-user-exposed-interfaces).
+- For HTTP/gRPC handlers, doctest the request/response types (serde round-trips, validation) and back the wire behaviour with integration tests.
+
+Doctests run as part of `cargo test --workspace`. A failing doctest is a failing test — fix it, don't ignore it. `#[doc(hidden)]` and `no_run` are escape hatches; justify each one with a comment.
+
+### Integration tests for user-exposed interfaces
+
+Every user-exposed interface ships an **integration test** that exercises the **compiled binary or compiled library entry point**, not just internal functions. Doctests prove the API shape is right; integration tests prove the artifact actually works after a real build.
+
+Rules by surface:
+
+- **CLI (`uncharles` and any future binary)** — integration tests under `tests/` that invoke the compiled binary via `assert_cmd` (or equivalent) and assert on **stdout**, **stderr**, and **exit code**. Cover at minimum:
+  - `--help` and `--version` succeed and contain the expected sections.
+  - The happy path with a side-effect-free config (e.g. `cmd: ["true"]`).
+  - One representative error path (bad config, missing flag, etc.) returning a non-zero exit code with a useful stderr message.
+- **Library APIs (`grafo`, `goap-planner`)** — integration tests under `tests/` that link the crate as an external consumer would (no access to private items). This catches `pub(crate)` leaks and surface-area regressions that unit tests inside the crate cannot.
+- **HTTP/gRPC handlers** — spin up the real router/server in the test, drive it over the wire (loopback), and assert on status code, headers, and body. Mock external dependencies, never the transport.
+- **YAML/config schemas** — round-trip representative configs from `configs/` (or a test fixture) through `serde` and assert the resulting in-memory shape.
+
+Integration tests must run as part of `cargo test --workspace`. They may be slower than unit tests; that is acceptable. Mark genuinely slow tests (`> 1s`) with `#[ignore]` only with a comment explaining why and how to run them in CI.
+
+For CLI specifically, see also [CLI conventions](#cli-conventions-posix--kubectl) — the integration tests are how those conventions are verified.
+
+## Performance and concurrency
+
+Performance is a first-class requirement, not an afterthought. The workspace exists to plan and execute actions; both the planner kernel (`goap-planner` over `grafo`) and the runtime (`uncharles`) sit on hot paths a user will feel.
+
+Default to Rust's memory-safety + zero-cost-abstraction posture: the compiler's guarantees are what make aggressive optimisation safe here, so use them rather than working around them.
+
+### Memory and ownership
+
+- **Avoid unnecessary allocation.** Prefer `&str` over `String`, `&[T]` over `Vec<T>`, and iterator chains over intermediate collections. Allocate when an owned value crosses an ownership boundary or is genuinely needed; not by reflex.
+- **Reuse buffers in hot loops.** A `Vec` or `String` cleared with `.clear()` keeps its capacity. A `HashMap` cleared with `.clear()` does too. Reach for this before reaching for `Rc`/`Arc`.
+- **Prefer borrowing to cloning.** Every `.clone()` in a hot path needs a one-line comment justifying it (cheap `Arc` clone, required by trait, etc.) or it should be removed.
+- **Use `Cow<'_, T>` when a value is *sometimes* owned.** Don't pay the allocation cost on the borrowed path.
+- **Choose the right collection.** `Vec` for ordered/dense, `HashMap`/`HashSet` for keyed lookup, `BTreeMap`/`BTreeSet` for ordered keyed lookup, `SmallVec`/`tinyvec` for short-lived small collections that would otherwise heap-allocate. Profile before adding a new collection dep.
+- **Reach for `unsafe` only with a written justification.** A `// SAFETY:` comment naming the invariants is mandatory. New `unsafe` in `grafo` or `goap-planner` requires a benchmark showing the safe version is materially slower.
+- **Minimise dynamic dispatch on hot paths.** Prefer generics + monomorphisation (`impl Trait`, `T: Trait`) over `Box<dyn Trait>` when the call site is hot. `dyn` is fine for cold setup code, plugin boundaries, and heterogeneous collections.
+- **Avoid `.unwrap()` / `.expect()` in library code.** Return `Result`; let the caller decide. In `uncharles` they're acceptable at the binary entry point with a clear message.
+
+### Async vs Rayon decision rule
+
+Pick the concurrency model by **what the work is bound on**, not by which framework you used last:
+
+| Work type                                                | Use      | Why                                                                 |
+| -------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| Network I/O — HTTP, gRPC, DNS, TCP, cloud SDKs           | `async`  | Latency varies wildly; tasks block on the network, not the CPU.     |
+| Disk I/O with high latency variance (e.g. remote FS, S3) | `async`  | Same reasoning as network.                                          |
+| Subprocess / shell exec waited on a timeout              | `async`  | Wait time is unpredictable; concurrent waits multiplex cleanly.     |
+| CPU-bound iteration over an unordered collection         | `rayon`  | Embarrassingly parallel; result order doesn't matter.               |
+| CPU-bound graph/planner search (`grafo`, `goap-planner`) | sync     | Already tight, latency-sensitive, single-threaded by design today.  |
+| Tiny bookkeeping (< ~10 µs total)                        | sync     | Concurrency overhead exceeds the work.                              |
+
+Rules:
+
+- **`async` for variable-latency I/O.** All new HTTP, gRPC, and network code is `async` and runs on the workspace runtime (`tokio`). Block-on bridges (`block_on`, `spawn_blocking`) are allowed at the binary boundary or to call legacy sync code; document why at the call site.
+- **No `async` in `goap-planner`.** It is a pure CPU library; keep it that way (see workspace `CLAUDE.md`'s layering rule). I/O concerns belong in `uncharles`.
+- **`rayon` when ordering doesn't matter.** Iterating a list to compute or filter where the order of processing and the order of results are both irrelevant → `par_iter` / `par_iter_mut` / `into_par_iter`. Preserve sequential iteration when ordering or early-exit semantics matter.
+- **Don't mix `rayon` inside an `async` task** without `spawn_blocking` or `tokio::task::block_in_place` — `rayon`'s thread pool will starve the async runtime otherwise. Document the bridge.
+- **Measure before parallelising.** A `rayon` conversion that doesn't move a benchmark number is dead weight; revert it. Pair the change with a [`docs/perf-comparison-YYYY-MM-DD.md`](./performance-tests.md) entry.
+- **Don't parallelise inside `grafo`/`goap-planner` without an issue.** Adding `rayon` to a core library is a design decision (changes Send/Sync requirements on user types); open a `type:design` issue first.
+
+### Always build `--release` for perf work
+
+Debug builds are 10×–100× slower than release builds and have *no* relation to production performance. Any time you measure, profile, or demonstrate performance, build with `--release`:
+
+- **Benchmarks**: `cargo bench` is release by default — don't override it.
+- **Flamegraphs**: `cargo flamegraph --release ...` (per [`performance-tests.md`](./performance-tests.md)).
+- **Manual timing of an example or binary**: `cargo run --release --bin <name>` or `cargo run --release --example <name>`.
+- **Reproducing a perf bug locally**: `--release` first; only drop to debug if you need symbol-level detail the release build doesn't expose, and even then prefer `--release` with `[profile.release] debug = true` set in `Cargo.toml`.
+- **Running CI-equivalent perf checks**: match what `.github/workflows/bench.yml` does (release + the documented `$CRITERION_CI_FLAGS`).
+
+If a measurement looks anomalously slow, the first thing to check is whether the binary was built with `--release`. Numbers from a debug build are not evidence and must not be quoted in PR descriptions or perf comparisons.
+
 ## Performance tests for core libraries
 
 Any crate used as a dependency by at least one other crate in this workspace ("core library") **must** ship a benchmark suite. Today that is `grafo` (consumed by `goap-planner` and indirectly by `uncharles`) and `goap-planner` (consumed by `uncharles`); the rule applies automatically to any future crate that gains a workspace-internal consumer. The full guideline — required surface (`Cargo.toml`, `benches/performance.rs`, `docs/performance.md`, `docs/bench-<label>.txt`, `docs/perf-comparison-YYYY-MM-DD.md`, `docs/flamegraph-<label>.svg`), workflow, trigger conditions, and CI enforcement — lives in [`performance-tests.md`](./performance-tests.md).
 
 Read that file before touching a core library's hot path or adding a new core crate. Pair every benchmark run with a flamegraph; pair every change that moves the headline numbers with a `perf-comparison-YYYY-MM-DD.md` snapshot and refresh the canonical `docs/performance.md`. CI enforces these rules on PRs touching a core library — see [`performance-tests.md`](./performance-tests.md) and `.github/workflows/bench.yml`.
+
+## CLI conventions (POSIX + kubectl)
+
+`uncharles` is the workspace's CLI today; any future binary follows the same rules. The CLI is a user-exposed interface, so [doctests](#doctests-on-user-exposed-interfaces) and [integration tests](#integration-tests-for-user-exposed-interfaces) both apply.
+
+### POSIX baseline
+
+Follow the [POSIX Utility Conventions](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html):
+
+- **Short flags are single dashes**: `-v`, `-h`. Short flags can stack: `-vh` ≡ `-v -h`.
+- **Long flags are double dashes**: `--verbose`, `--help`. Long flags use kebab-case: `--dry-run`, not `--dryRun` or `--dry_run`.
+- **`--` ends option parsing.** Anything after `--` is positional, even if it starts with `-`.
+- **`-` means stdin/stdout** when used in place of a path argument.
+- **Exit codes**: `0` on success, non-zero on failure. Reserve `2` for usage errors (bad flags, missing required args). Document any custom exit codes in `--help` and in the binary's module docs.
+- **Errors go to stderr; data goes to stdout.** Never mix them. Piping the stdout of one invocation into another must work without filtering.
+- **Respect `NO_COLOR`** (https://no-color.org/) and only emit ANSI colour to a TTY by default. Provide `--color=auto|always|never` matching coreutils.
+- **`--help` and `--version` succeed with exit code `0`** and write to stdout. They never require a config file or network.
+
+### kubectl-inspired structure
+
+Model the command tree on `kubectl`'s `verb [resource] [name] [flags]` shape. It is the most widely-internalised CLI grammar in our domain; matching it lowers the cognitive load for operators.
+
+- **Verb-first subcommands**: `uncharles run`, `uncharles validate`, `uncharles describe`, `uncharles plan`. Verbs are imperative and lower-case.
+- **Resource as second token where it makes sense**: `uncharles get plan <name>`, `uncharles describe sensor <name>`. Singular resource names; plural is acceptable for list verbs (`uncharles get plans`).
+- **Global flags before the verb or anywhere after, both should parse**: `-v`, `--config`, `--context`, `--namespace`-equivalent (if/when relevant). Use [`clap`](https://docs.rs/clap)'s derive API and put global flags on the top-level struct.
+- **`--output` / `-o` for format selection**: support at least `-o yaml` and `-o json` for any subcommand that prints structured data. Default to a human-readable table or summary on a TTY.
+- **`--dry-run`**: any subcommand that mutates state (executes actions, writes files, hits an API) supports `--dry-run` and prints what it would do without doing it.
+- **`--config <path>` / `KUBECONFIG`-style env**: configs are discovered in this order: `--config` flag → env var (`UNCHARLES_CONFIG` or equivalent) → `./<default>.yaml` → XDG config dir. Document the order in `--help`.
+- **Sensible auto-completion**: expose `uncharles completion bash|zsh|fish|powershell` (clap supports this with `clap_complete`).
+- **Stable subcommand names**. Renaming a verb or resource is a breaking change — flag it with `!` and a `BREAKING CHANGE:` footer in the commit (see [Commits and pull requests](#commits-and-pull-requests)).
+
+### What to test
+
+The CLI's [integration tests](#integration-tests-for-user-exposed-interfaces) verify the conventions above:
+
+- `--help`, `--version`, and each subcommand's `--help` exit `0`, write to stdout, and contain the documented sections.
+- A bad flag exits `2` with a useful stderr message.
+- `-o json` and `-o yaml` round-trip through `serde_json::Value` / `serde_yaml::Value` cleanly.
+- `--dry-run` produces no side effects (no files written, no commands executed) — assert with a config that would be detectable if executed (e.g. `cmd: ["false"]` and assert exit code `0` under `--dry-run`).
 
 ## Lint and format
 
@@ -47,11 +204,12 @@ When a change alters behaviour or public interface, update the docs in the same 
 
 After a behaviour or interface change, update each that applies:
 
-- **Docstrings** (`///` and `//!`) on every changed public item — function summary, parameters, return value, panic conditions, error variants. Make them reflect the new behaviour exactly.
+- **Docstrings** (`///` and `//!`) on every changed public item — function summary, parameters, return value, panic conditions, error variants. Make them reflect the new behaviour exactly. See [Doctests on user-exposed interfaces](#doctests-on-user-exposed-interfaces) for required structure.
 - **Module-level docs** at the top of `lib.rs` / `main.rs` if the change affects the module's role or surface.
 - **Doctests** must compile and assert the new behaviour. They are part of the test suite — a broken example is a broken test.
 - **Example binaries** under `examples/` that use the changed API.
 - **YAML configs** under `uncharles/configs/` if the schema changed.
+- **CLI `--help` text and `uncharles/docs/`** if a verb, flag, resource, or output format changed (see [CLI conventions](#cli-conventions-posix--kubectl)).
 - **`CLAUDE.md`** files at the relevant scope if the change invalidates rules captured there.
 - **`docs/todo.md`** if the change resolves a tracked item — remove or strike the entry.
 
@@ -95,3 +253,10 @@ Breaking changes are flagged two ways together: a `!` after the type/scope (`fea
 ## When in doubt
 
 If a change is non-trivial and the right-sized test, lint posture, or documentation update is unclear, prefer the more thorough option. The cost of an extra test or a fuller docstring is minutes; the cost of a regression or a stale doc compounds.
+
+Specifically:
+
+- **Unsure if it needs a doctest?** Add one. Public API without a runnable example is half-documented.
+- **Unsure if `async` or `rayon` is right?** Re-read [Async vs Rayon](#async-vs-rayon-decision-rule) and pick by what the work is bound on. If still unsure, default to sync and open an issue.
+- **Unsure if a perf change is real?** It isn't, until you've measured under `--release` with the benchmark suite and pasted the numbers in the PR.
+- **Unsure if a CLI flag follows POSIX?** Check the table in [CLI conventions](#cli-conventions-posix--kubectl) and `kubectl`'s equivalent flag; match the more conservative of the two.

--- a/goap-planner/src/explore.rs
+++ b/goap-planner/src/explore.rs
@@ -1,0 +1,108 @@
+//! State-space enumeration for [`crate::Planner`].
+//!
+//! [`Planner::plan`] runs forward BFS, builds a state-action graph, and then
+//! discards the graph after Dijkstra has selected the cheapest path. That's
+//! the right shape for production planning, but inspection tools (config
+//! debuggers, visualisers, regression tests) need the structure itself.
+//! [`Planner::explore`] returns it as a [`StateGraph`].
+//!
+//! [`Planner::plan`]: crate::Planner::plan
+//! [`Planner::explore`]: crate::Planner::explore
+
+use std::collections::BTreeSet;
+
+/// The bounded state-action graph reachable from a given initial state.
+///
+/// Returned by [`crate::Planner::explore`]. Use this for inspection,
+/// visualisation, and static analysis. For finding the cheapest plan,
+/// call [`crate::Planner::plan`] instead — it runs Dijkstra over this same
+/// graph internally.
+///
+/// Iteration order is stable: `states` is sorted by signature, `edges` is
+/// sorted by `(from, action, to)`, and `goal_satisfying` is sorted.
+///
+/// # Examples
+///
+/// ```
+/// use goap_planner::{Action, Planner, State};
+///
+/// let actions = vec![
+///     Action::new("chop_tree", 5.0).requires("has_axe").adds("has_log").removes("has_axe"),
+///     Action::new("split_log", 2.0).requires("has_log").adds("has_firewood").removes("has_log"),
+/// ];
+/// let initial = State::from_facts(["has_axe"]);
+/// let graph = Planner::new(actions).explore(&initial);
+///
+/// assert_eq!(graph.states.len(), 3);              // initial + after-chop + after-split
+/// assert_eq!(graph.edges.len(), 2);
+/// assert!(!graph.truncated);
+/// // The goal `has_firewood` isn't asked here — explore is goal-agnostic.
+/// assert!(graph.goal_satisfying.is_empty());
+/// ```
+#[derive(Debug, Clone)]
+pub struct StateGraph {
+    /// All discovered states, sorted by [`StateNode::signature`].
+    pub states: Vec<StateNode>,
+    /// All transitions between discovered states, sorted by
+    /// `(from, action, to)`. When several actions connect the same pair
+    /// of states, the cheapest is kept (consistent with [`crate::Planner::plan`]'s
+    /// shortest-path selection).
+    pub edges: Vec<StateEdge>,
+    /// Index of the initial state in `states`.
+    pub initial: usize,
+    /// Indices of the states that satisfy the goal passed to
+    /// [`crate::Planner::explore_for_goal`]. Empty for goal-agnostic exploration.
+    pub goal_satisfying: Vec<usize>,
+    /// `true` if BFS hit the planner's `max_states` cap and stopped before
+    /// exhausting the reachable state space. The returned graph is still
+    /// usable, but it is a partial view: there may be states or edges that
+    /// would have been discovered with a larger cap.
+    pub truncated: bool,
+}
+
+/// A single discovered state in a [`StateGraph`].
+///
+/// `signature` is the canonical string returned by
+/// [`crate::State::signature`]; two `StateNode`s with the same signature
+/// represent the same world state. `facts` is the same set of facts in
+/// sorted form, ready for stable display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateNode {
+    /// Canonical signature of the state.
+    pub signature: String,
+    /// Sorted facts that hold in this state.
+    pub facts: BTreeSet<String>,
+}
+
+/// A directed transition between two states in a [`StateGraph`], produced
+/// by an action firing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateEdge {
+    /// Index of the source state in [`StateGraph::states`].
+    pub from: usize,
+    /// Index of the destination state.
+    pub to: usize,
+    /// Name of the action that produced this transition (the cheapest
+    /// action when multiple actions connect the same pair of states).
+    pub action: String,
+    /// Cost of the action.
+    pub cost: f64,
+}
+
+impl StateGraph {
+    /// Iterates over the outgoing edges of a given state index.
+    ///
+    /// Convenience wrapper over the `edges` slice. Edges are pre-sorted by
+    /// `(from, action, to)`, so this returns them in stable order.
+    pub fn outgoing(&self, state_idx: usize) -> impl Iterator<Item = &StateEdge> {
+        self.edges.iter().filter(move |e| e.from == state_idx)
+    }
+
+    /// Returns `true` if the given state index has no outgoing edges.
+    ///
+    /// Combined with `goal_satisfying`, this identifies dead-end states:
+    /// `is_dead_end(i) && !goal_satisfying.contains(&i)`.
+    pub fn is_dead_end(&self, state_idx: usize) -> bool {
+        self.outgoing(state_idx).next().is_none()
+    }
+}

--- a/goap-planner/src/lib.rs
+++ b/goap-planner/src/lib.rs
@@ -34,12 +34,14 @@
 //! ```
 
 mod action;
+mod explore;
 mod goal;
 mod plan;
 mod planner;
 mod state;
 
 pub use action::Action;
+pub use explore::{StateEdge, StateGraph, StateNode};
 pub use goal::Goal;
 pub use plan::Plan;
 pub use planner::{Planner, PlannerError};

--- a/goap-planner/src/planner.rs
+++ b/goap-planner/src/planner.rs
@@ -1,10 +1,11 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::fmt;
 
 use grafo::Graph;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::action::Action;
+use crate::explore::{StateEdge, StateGraph, StateNode};
 use crate::goal::Goal;
 use crate::plan::Plan;
 use crate::state::State;
@@ -51,10 +52,63 @@ impl Planner {
     }
 
     /// Cap on reachable states explored before [`PlannerError::StateSpaceLimitExceeded`]
-    /// is returned. Defaults to 10_000.
+    /// is returned by [`Planner::plan`], or before [`Planner::explore`] sets
+    /// [`StateGraph::truncated`]. Defaults to 10_000.
     pub fn with_max_states(mut self, max_states: usize) -> Self {
         self.max_states = max_states;
         self
+    }
+
+    /// Enumerate the bounded state-action graph reachable from `initial`.
+    ///
+    /// Goal-agnostic: the returned [`StateGraph::goal_satisfying`] is empty.
+    /// Use [`Planner::explore_for_goal`] when you also want to know which
+    /// of the discovered states satisfy a goal.
+    ///
+    /// Never returns an error for hitting `max_states`; instead, the BFS
+    /// stops cleanly and [`StateGraph::truncated`] is set to `true`. The
+    /// returned graph is a partial but consistent view of what's been
+    /// explored so far.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use goap_planner::{Action, Planner, State};
+    ///
+    /// let actions = vec![
+    ///     Action::new("step", 1.0).requires("a").adds("b").removes("a"),
+    /// ];
+    /// let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+    /// assert_eq!(graph.states.len(), 2);
+    /// assert_eq!(graph.edges.len(), 1);
+    /// assert_eq!(graph.edges[0].action, "step");
+    /// ```
+    pub fn explore(&self, initial: &State) -> StateGraph {
+        self.bfs(initial, None)
+    }
+
+    /// Like [`Planner::explore`], but additionally records which discovered
+    /// states satisfy `goal` in [`StateGraph::goal_satisfying`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use goap_planner::{Action, Goal, Planner, State};
+    ///
+    /// let actions = vec![
+    ///     Action::new("chop", 5.0).requires("axe").adds("log").removes("axe"),
+    ///     Action::new("split", 2.0).requires("log").adds("firewood").removes("log"),
+    /// ];
+    /// let initial = State::from_facts(["axe"]);
+    /// let goal = Goal::new().requires("firewood");
+    /// let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+    ///
+    /// assert_eq!(graph.goal_satisfying.len(), 1);
+    /// let goal_state = &graph.states[graph.goal_satisfying[0]];
+    /// assert!(goal_state.facts.contains("firewood"));
+    /// ```
+    pub fn explore_for_goal(&self, initial: &State, goal: &Goal) -> StateGraph {
+        self.bfs(initial, Some(goal))
     }
 
     /// Plan from `initial` to any state satisfying `goal`.
@@ -70,21 +124,114 @@ impl Planner {
             }));
         }
 
+        let graph = self.explore_for_goal(initial, goal);
+        if graph.truncated {
+            return Err(PlannerError::StateSpaceLimitExceeded {
+                max_states: self.max_states,
+            });
+        }
+        if graph.goal_satisfying.is_empty() {
+            return Ok(None);
+        }
+
+        // Build a grafo::Graph over the discovered states and run Dijkstra
+        // from initial to the synthetic GOAL_SINK linked from every
+        // goal-satisfying state.
+        let mut nodes: Vec<&str> = graph.states.iter().map(|s| s.signature.as_str()).collect();
+        nodes.push(GOAL_SINK);
+
+        let mut edges: Vec<(&str, &str, f64)> = graph
+            .edges
+            .iter()
+            .map(|e| {
+                (
+                    graph.states[e.from].signature.as_str(),
+                    graph.states[e.to].signature.as_str(),
+                    e.cost,
+                )
+            })
+            .collect();
+        for &gs in &graph.goal_satisfying {
+            edges.push((graph.states[gs].signature.as_str(), GOAL_SINK, 0.0));
+        }
+
+        let g = Graph::new(&nodes, &edges)?;
+        let initial_sig = graph.states[graph.initial].signature.as_str();
+
+        let path = match g.shortest_path(initial_sig, GOAL_SINK)? {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        // Reconstruct action names from the path. For each consecutive pair
+        // of state signatures, look up the cheapest edge (which `explore`
+        // already kept) and emit its action name.
+        let labels = path.resolve_labels(&g);
+        let edge_lookup: FxHashMap<(String, String), &StateEdge> = graph
+            .edges
+            .iter()
+            .map(|e| {
+                (
+                    (
+                        graph.states[e.from].signature.clone(),
+                        graph.states[e.to].signature.clone(),
+                    ),
+                    e,
+                )
+            })
+            .collect();
+
+        let steps: Vec<String> = labels
+            .windows(2)
+            .filter_map(|pair| {
+                if pair[1] == GOAL_SINK {
+                    None
+                } else {
+                    edge_lookup
+                        .get(&(pair[0].clone(), pair[1].clone()))
+                        .map(|e| e.action.clone())
+                }
+            })
+            .collect();
+
+        Ok(Some(Plan {
+            steps,
+            cost: path.cost,
+        }))
+    }
+
+    /// Internal BFS over the state space, shared by [`Planner::explore`]
+    /// and [`Planner::explore_for_goal`].
+    ///
+    /// When `goal` is `Some`, every discovered state is checked against it
+    /// and recorded in `goal_satisfying`. When `None`, that work is skipped.
+    fn bfs(&self, initial: &State, goal: Option<&Goal>) -> StateGraph {
         let initial_sig = initial.signature();
+
+        // Internal BFS uses fast Fx hashing; we sort once at the end for
+        // a stable public iteration order.
         let mut signatures: FxHashMap<String, State> = FxHashMap::default();
         signatures.insert(initial_sig.clone(), initial.clone());
 
         let mut edge_map: FxHashMap<(String, String), (f64, String)> = FxHashMap::default();
-        let mut goal_states: FxHashSet<String> = FxHashSet::default();
+        let mut goal_state_sigs: FxHashSet<String> = FxHashSet::default();
+
+        // Check the initial state itself for goal satisfaction.
+        if let Some(g) = goal
+            && g.satisfied_by(initial)
+        {
+            goal_state_sigs.insert(initial_sig.clone());
+        }
 
         let mut queue: VecDeque<String> = VecDeque::new();
         queue.push_back(initial_sig.clone());
 
+        let mut truncated = false;
+
         while let Some(sig) = queue.pop_front() {
             if signatures.len() > self.max_states {
-                return Err(PlannerError::StateSpaceLimitExceeded {
-                    max_states: self.max_states,
-                });
+                truncated = true;
+                break;
             }
 
             let state = signatures[&sig].clone();
@@ -111,56 +258,58 @@ impl Planner {
                     })
                     .or_insert((action.cost, action.name.clone()));
 
-                if goal.satisfied_by(&next) {
-                    goal_states.insert(next_sig.clone());
+                if let Some(g) = goal
+                    && g.satisfied_by(&next)
+                {
+                    goal_state_sigs.insert(next_sig.clone());
                 }
             }
         }
 
-        if goal_states.is_empty() {
-            return Ok(None);
-        }
-
-        let mut nodes: Vec<String> = signatures.keys().cloned().collect();
-        nodes.push(GOAL_SINK.to_string());
-
-        let mut edges: Vec<(String, String, f64)> = edge_map
+        // Convert to the public, stable-ordered structure.
+        let mut states: Vec<StateNode> = signatures
             .iter()
-            .map(|((from, to), (cost, _))| (from.clone(), to.clone(), *cost))
-            .collect();
-        for gs in &goal_states {
-            edges.push((gs.clone(), GOAL_SINK.to_string(), 0.0));
-        }
-
-        let node_refs: Vec<&str> = nodes.iter().map(String::as_str).collect();
-        let edge_refs: Vec<(&str, &str, f64)> = edges
-            .iter()
-            .map(|(a, b, c)| (a.as_str(), b.as_str(), *c))
-            .collect();
-        let graph = Graph::new(&node_refs, &edge_refs)?;
-
-        let path = match graph.shortest_path(&initial_sig, GOAL_SINK)? {
-            Some(p) => p,
-            None => return Ok(None),
-        };
-
-        let labels = path.resolve_labels(&graph);
-        let steps: Vec<String> = labels
-            .windows(2)
-            .filter_map(|pair| {
-                if pair[1] == GOAL_SINK {
-                    None
-                } else {
-                    edge_map
-                        .get(&(pair[0].clone(), pair[1].clone()))
-                        .map(|(_, name)| name.clone())
-                }
+            .map(|(sig, state)| StateNode {
+                signature: sig.clone(),
+                facts: state.facts().map(String::from).collect::<BTreeSet<_>>(),
             })
             .collect();
+        states.sort_by(|a, b| a.signature.cmp(&b.signature));
 
-        Ok(Some(Plan {
-            steps,
-            cost: path.cost,
-        }))
+        let sig_to_idx: FxHashMap<String, usize> = states
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.signature.clone(), i))
+            .collect();
+
+        let mut edges: Vec<StateEdge> = edge_map
+            .into_iter()
+            .map(|((from, to), (cost, action))| StateEdge {
+                from: sig_to_idx[&from],
+                to: sig_to_idx[&to],
+                action,
+                cost,
+            })
+            .collect();
+        edges.sort_by(|a, b| {
+            a.from
+                .cmp(&b.from)
+                .then(a.action.cmp(&b.action))
+                .then(a.to.cmp(&b.to))
+        });
+
+        let initial_idx = sig_to_idx[&initial_sig];
+
+        let mut goal_satisfying: Vec<usize> =
+            goal_state_sigs.iter().map(|sig| sig_to_idx[sig]).collect();
+        goal_satisfying.sort();
+
+        StateGraph {
+            states,
+            edges,
+            initial: initial_idx,
+            goal_satisfying,
+            truncated,
+        }
     }
 }

--- a/goap-planner/src/planner.rs
+++ b/goap-planner/src/planner.rs
@@ -84,7 +84,7 @@ impl Planner {
     /// assert_eq!(graph.edges[0].action, "step");
     /// ```
     pub fn explore(&self, initial: &State) -> StateGraph {
-        self.bfs(initial, None)
+        materialise(self.bfs_raw(initial, None))
     }
 
     /// Like [`Planner::explore`], but additionally records which discovered
@@ -108,7 +108,7 @@ impl Planner {
     /// assert!(goal_state.facts.contains("firewood"));
     /// ```
     pub fn explore_for_goal(&self, initial: &State, goal: &Goal) -> StateGraph {
-        self.bfs(initial, Some(goal))
+        materialise(self.bfs_raw(initial, Some(goal)))
     }
 
     /// Plan from `initial` to any state satisfying `goal`.
@@ -124,72 +124,57 @@ impl Planner {
             }));
         }
 
-        let graph = self.explore_for_goal(initial, goal);
-        if graph.truncated {
+        // Use the raw (unmaterialised) BFS so plan does not pay for
+        // sorting, BTreeSet construction per state, or sig-to-index
+        // bookkeeping that only the public StateGraph needs. plan() only
+        // wants the raw signatures / edge map / goal sigs.
+        let raw = self.bfs_raw(initial, Some(goal));
+        if raw.truncated {
             return Err(PlannerError::StateSpaceLimitExceeded {
                 max_states: self.max_states,
             });
         }
-        if graph.goal_satisfying.is_empty() {
+        if raw.goal_state_sigs.is_empty() {
             return Ok(None);
         }
 
-        // Build a grafo::Graph over the discovered states and run Dijkstra
-        // from initial to the synthetic GOAL_SINK linked from every
-        // goal-satisfying state.
-        let mut nodes: Vec<&str> = graph.states.iter().map(|s| s.signature.as_str()).collect();
-        nodes.push(GOAL_SINK);
+        // Build a grafo::Graph over the discovered signatures and run
+        // Dijkstra from initial to the synthetic GOAL_SINK that's linked
+        // from every goal-satisfying state.
+        let mut nodes: Vec<String> = raw.signatures.keys().cloned().collect();
+        nodes.push(GOAL_SINK.to_string());
 
-        let mut edges: Vec<(&str, &str, f64)> = graph
-            .edges
+        let mut edges: Vec<(String, String, f64)> = raw
+            .edge_map
             .iter()
-            .map(|e| {
-                (
-                    graph.states[e.from].signature.as_str(),
-                    graph.states[e.to].signature.as_str(),
-                    e.cost,
-                )
-            })
+            .map(|((from, to), (cost, _))| (from.clone(), to.clone(), *cost))
             .collect();
-        for &gs in &graph.goal_satisfying {
-            edges.push((graph.states[gs].signature.as_str(), GOAL_SINK, 0.0));
+        for gs in &raw.goal_state_sigs {
+            edges.push((gs.clone(), GOAL_SINK.to_string(), 0.0));
         }
 
-        let g = Graph::new(&nodes, &edges)?;
-        let initial_sig = graph.states[graph.initial].signature.as_str();
+        let node_refs: Vec<&str> = nodes.iter().map(String::as_str).collect();
+        let edge_refs: Vec<(&str, &str, f64)> = edges
+            .iter()
+            .map(|(a, b, c)| (a.as_str(), b.as_str(), *c))
+            .collect();
+        let graph = Graph::new(&node_refs, &edge_refs)?;
 
-        let path = match g.shortest_path(initial_sig, GOAL_SINK)? {
+        let path = match graph.shortest_path(&raw.initial_sig, GOAL_SINK)? {
             Some(p) => p,
             None => return Ok(None),
         };
 
-        // Reconstruct action names from the path. For each consecutive pair
-        // of state signatures, look up the cheapest edge (which `explore`
-        // already kept) and emit its action name.
-        let labels = path.resolve_labels(&g);
-        let edge_lookup: FxHashMap<(String, String), &StateEdge> = graph
-            .edges
-            .iter()
-            .map(|e| {
-                (
-                    (
-                        graph.states[e.from].signature.clone(),
-                        graph.states[e.to].signature.clone(),
-                    ),
-                    e,
-                )
-            })
-            .collect();
-
+        let labels = path.resolve_labels(&graph);
         let steps: Vec<String> = labels
             .windows(2)
             .filter_map(|pair| {
                 if pair[1] == GOAL_SINK {
                     None
                 } else {
-                    edge_lookup
+                    raw.edge_map
                         .get(&(pair[0].clone(), pair[1].clone()))
-                        .map(|e| e.action.clone())
+                        .map(|(_, name)| name.clone())
                 }
             })
             .collect();
@@ -200,16 +185,18 @@ impl Planner {
         }))
     }
 
-    /// Internal BFS over the state space, shared by [`Planner::explore`]
-    /// and [`Planner::explore_for_goal`].
+    /// Internal BFS over the state space, shared by [`Planner::explore`],
+    /// [`Planner::explore_for_goal`], and [`Planner::plan`]. Returns the
+    /// raw `FxHashMap`-backed structures so callers that don't need the
+    /// public, stable-ordered [`StateGraph`] (i.e. `plan`) avoid paying
+    /// for the materialisation step.
     ///
-    /// When `goal` is `Some`, every discovered state is checked against it
-    /// and recorded in `goal_satisfying`. When `None`, that work is skipped.
-    fn bfs(&self, initial: &State, goal: Option<&Goal>) -> StateGraph {
+    /// When `goal` is `Some`, every discovered state is checked against
+    /// it and the satisfying signatures are recorded. When `None`, that
+    /// work is skipped.
+    fn bfs_raw(&self, initial: &State, goal: Option<&Goal>) -> RawBfs {
         let initial_sig = initial.signature();
 
-        // Internal BFS uses fast Fx hashing; we sort once at the end for
-        // a stable public iteration order.
         let mut signatures: FxHashMap<String, State> = FxHashMap::default();
         signatures.insert(initial_sig.clone(), initial.clone());
 
@@ -266,50 +253,82 @@ impl Planner {
             }
         }
 
-        // Convert to the public, stable-ordered structure.
-        let mut states: Vec<StateNode> = signatures
-            .iter()
-            .map(|(sig, state)| StateNode {
-                signature: sig.clone(),
-                facts: state.facts().map(String::from).collect::<BTreeSet<_>>(),
-            })
-            .collect();
-        states.sort_by(|a, b| a.signature.cmp(&b.signature));
-
-        let sig_to_idx: FxHashMap<String, usize> = states
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n.signature.clone(), i))
-            .collect();
-
-        let mut edges: Vec<StateEdge> = edge_map
-            .into_iter()
-            .map(|((from, to), (cost, action))| StateEdge {
-                from: sig_to_idx[&from],
-                to: sig_to_idx[&to],
-                action,
-                cost,
-            })
-            .collect();
-        edges.sort_by(|a, b| {
-            a.from
-                .cmp(&b.from)
-                .then(a.action.cmp(&b.action))
-                .then(a.to.cmp(&b.to))
-        });
-
-        let initial_idx = sig_to_idx[&initial_sig];
-
-        let mut goal_satisfying: Vec<usize> =
-            goal_state_sigs.iter().map(|sig| sig_to_idx[sig]).collect();
-        goal_satisfying.sort();
-
-        StateGraph {
-            states,
-            edges,
-            initial: initial_idx,
-            goal_satisfying,
+        RawBfs {
+            signatures,
+            edge_map,
+            goal_state_sigs,
+            initial_sig,
             truncated,
         }
+    }
+}
+
+/// Raw output of [`Planner::bfs_raw`], before any sorting or
+/// materialisation. Internal-only: callers that want a stable, sorted
+/// public view go through [`materialise`].
+struct RawBfs {
+    signatures: FxHashMap<String, State>,
+    edge_map: FxHashMap<(String, String), (f64, String)>,
+    goal_state_sigs: FxHashSet<String>,
+    initial_sig: String,
+    truncated: bool,
+}
+
+/// Convert the raw BFS output into a stable-ordered public [`StateGraph`].
+///
+/// This is the work the inspection API pays for, kept out of the
+/// performance-sensitive [`Planner::plan`] path.
+fn materialise(raw: RawBfs) -> StateGraph {
+    let RawBfs {
+        signatures,
+        edge_map,
+        goal_state_sigs,
+        initial_sig,
+        truncated,
+    } = raw;
+
+    let mut states: Vec<StateNode> = signatures
+        .iter()
+        .map(|(sig, state)| StateNode {
+            signature: sig.clone(),
+            facts: state.facts().map(String::from).collect::<BTreeSet<_>>(),
+        })
+        .collect();
+    states.sort_by(|a, b| a.signature.cmp(&b.signature));
+
+    let sig_to_idx: FxHashMap<String, usize> = states
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.signature.clone(), i))
+        .collect();
+
+    let mut edges: Vec<StateEdge> = edge_map
+        .into_iter()
+        .map(|((from, to), (cost, action))| StateEdge {
+            from: sig_to_idx[&from],
+            to: sig_to_idx[&to],
+            action,
+            cost,
+        })
+        .collect();
+    edges.sort_by(|a, b| {
+        a.from
+            .cmp(&b.from)
+            .then(a.action.cmp(&b.action))
+            .then(a.to.cmp(&b.to))
+    });
+
+    let initial_idx = sig_to_idx[&initial_sig];
+
+    let mut goal_satisfying: Vec<usize> =
+        goal_state_sigs.iter().map(|sig| sig_to_idx[sig]).collect();
+    goal_satisfying.sort();
+
+    StateGraph {
+        states,
+        edges,
+        initial: initial_idx,
+        goal_satisfying,
+        truncated,
     }
 }

--- a/goap-planner/tests/explore.rs
+++ b/goap-planner/tests/explore.rs
@@ -1,0 +1,303 @@
+//! Tests for [`Planner::explore`] and [`Planner::explore_for_goal`].
+//!
+//! `explore` is the inspection-time API. It returns the bounded state-action
+//! graph reachable from a given initial state, with stable iteration order
+//! and a `truncated` flag instead of an error when `max_states` is hit.
+//! These tests pin the contract: shape of the returned graph, goal-tracking
+//! semantics, dead-end detection, and truncation behaviour.
+
+use std::collections::BTreeSet;
+
+use goap_planner::{Action, Goal, Planner, State};
+
+// ---------------------------------------------------------------------------
+// Shapes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_action_library_yields_singleton_graph() {
+    let graph = Planner::new(Vec::new()).explore(&State::from_facts(["x"]));
+
+    assert_eq!(graph.states.len(), 1);
+    assert!(graph.edges.is_empty());
+    assert_eq!(graph.initial, 0);
+    assert!(graph.goal_satisfying.is_empty());
+    assert!(!graph.truncated);
+
+    let only = &graph.states[0];
+    let expected: BTreeSet<String> = ["x".to_string()].into_iter().collect();
+    assert_eq!(only.facts, expected);
+}
+
+#[test]
+fn linear_chain_produces_one_edge_per_step() {
+    // a → b → c → d via three actions.
+    let actions = vec![
+        Action::new("ab", 1.0).requires("a").adds("b").removes("a"),
+        Action::new("bc", 1.0).requires("b").adds("c").removes("b"),
+        Action::new("cd", 1.0).requires("c").adds("d").removes("c"),
+    ];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    assert_eq!(graph.states.len(), 4);
+    assert_eq!(graph.edges.len(), 3);
+    assert!(!graph.truncated);
+    assert!(graph.goal_satisfying.is_empty()); // goal-agnostic explore
+
+    // Each state is the initial of exactly one outgoing edge except the last.
+    let mut states_with_outgoing = std::collections::HashSet::new();
+    for e in &graph.edges {
+        states_with_outgoing.insert(e.from);
+    }
+    assert_eq!(states_with_outgoing.len(), 3);
+}
+
+#[test]
+fn redundant_paths_keep_cheapest_action_per_edge() {
+    // Two ways from {a} to {b}: via cheap_path (cost 1) and via expensive_path (cost 5).
+    // explore should keep the cheaper one — that's the contract plan() depends on.
+    let actions = vec![
+        Action::new("cheap_path", 1.0)
+            .requires("a")
+            .adds("b")
+            .removes("a"),
+        Action::new("expensive_path", 5.0)
+            .requires("a")
+            .adds("b")
+            .removes("a"),
+    ];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    assert_eq!(graph.states.len(), 2);
+    assert_eq!(graph.edges.len(), 1);
+    assert_eq!(graph.edges[0].action, "cheap_path");
+    assert_eq!(graph.edges[0].cost, 1.0);
+}
+
+#[test]
+fn explore_visits_all_branches_in_wide_graph() {
+    // From {start}, four actions each produce a distinct fact and consume start.
+    // Each branch is a one-step dead-end.
+    let actions = (0..4)
+        .map(|i| {
+            Action::new(format!("branch_{i}"), 1.0)
+                .requires("start")
+                .removes("start")
+                .adds(format!("done_{i}"))
+        })
+        .collect::<Vec<_>>();
+    let graph = Planner::new(actions).explore(&State::from_facts(["start"]));
+
+    // 1 initial state + 4 leaf states.
+    assert_eq!(graph.states.len(), 5);
+    assert_eq!(graph.edges.len(), 4);
+
+    // Initial has 4 outgoing edges; every leaf has 0.
+    let outgoing_counts: Vec<usize> = (0..graph.states.len())
+        .map(|i| graph.outgoing(i).count())
+        .collect();
+    let mut sorted = outgoing_counts.clone();
+    sorted.sort();
+    assert_eq!(sorted, vec![0, 0, 0, 0, 4]);
+}
+
+// ---------------------------------------------------------------------------
+// Stable iteration order — explicit checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn states_are_sorted_by_signature() {
+    let actions = vec![
+        Action::new("ab", 1.0).requires("a").adds("b"),
+        Action::new("ac", 1.0).requires("a").adds("c"),
+        Action::new("ad", 1.0).requires("a").adds("d"),
+    ];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    let signatures: Vec<&str> = graph.states.iter().map(|s| s.signature.as_str()).collect();
+    let mut sorted = signatures.clone();
+    sorted.sort();
+    assert_eq!(signatures, sorted);
+}
+
+#[test]
+fn edges_are_sorted_by_from_action_to() {
+    // Each action consumes "a" so they're one-shot from the initial state.
+    let actions = vec![
+        Action::new("z_action", 1.0)
+            .requires("a")
+            .adds("b")
+            .removes("a"),
+        Action::new("a_action", 1.0)
+            .requires("a")
+            .adds("c")
+            .removes("a"),
+    ];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    // Both edges originate from the {a}-state; "a_action" should come first.
+    let action_names: Vec<&str> = graph.edges.iter().map(|e| e.action.as_str()).collect();
+    assert_eq!(action_names, vec!["a_action", "z_action"]);
+}
+
+// ---------------------------------------------------------------------------
+// Goal tracking via explore_for_goal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explore_for_goal_records_goal_satisfying_states() {
+    // Linear, fully-consuming chain: {axe} → {log} → {firewood}.
+    let actions = vec![
+        Action::new("chop", 5.0)
+            .requires("axe")
+            .adds("log")
+            .removes("axe"),
+        Action::new("split", 2.0)
+            .requires("log")
+            .adds("firewood")
+            .removes("log"),
+    ];
+    let initial = State::from_facts(["axe"]);
+    let goal = Goal::new().requires("firewood");
+    let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+
+    assert_eq!(graph.goal_satisfying.len(), 1);
+    let goal_state = &graph.states[graph.goal_satisfying[0]];
+    assert!(goal_state.facts.contains("firewood"));
+    assert!(!goal_state.facts.contains("log"));
+    assert!(!goal_state.facts.contains("axe"));
+}
+
+#[test]
+fn explore_for_goal_initial_already_satisfies_records_initial() {
+    let initial = State::from_facts(["done"]);
+    let goal = Goal::new().requires("done");
+    let graph = Planner::new(Vec::new()).explore_for_goal(&initial, &goal);
+
+    assert_eq!(graph.states.len(), 1);
+    assert_eq!(graph.goal_satisfying, vec![0]);
+    assert_eq!(graph.initial, 0);
+}
+
+#[test]
+fn explore_for_goal_unreachable_returns_empty_goal_satisfying() {
+    // Goal requires a fact no action produces.
+    let actions = vec![Action::new("step", 1.0).requires("a").adds("b")];
+    let initial = State::from_facts(["a"]);
+    let goal = Goal::new().requires("c"); // no producer
+    let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+
+    assert_eq!(graph.states.len(), 2); // initial + after-step
+    assert!(graph.goal_satisfying.is_empty());
+    assert!(!graph.truncated);
+}
+
+#[test]
+fn explore_skips_goal_check_when_called_goal_agnostic() {
+    let actions = vec![Action::new("step", 1.0).requires("a").adds("b")];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    assert!(graph.goal_satisfying.is_empty());
+    // Even when the structurally-corresponding "goal {b}" would match a state,
+    // the goal-agnostic API doesn't track it.
+}
+
+// ---------------------------------------------------------------------------
+// Dead-end detection helper
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_dead_end_identifies_states_with_no_outgoing() {
+    // a → b is the only transition; b has no outgoing.
+    let actions = vec![
+        Action::new("step", 1.0)
+            .requires("a")
+            .adds("b")
+            .removes("a"),
+    ];
+    let graph = Planner::new(actions).explore(&State::from_facts(["a"]));
+
+    let initial_dead = graph.is_dead_end(graph.initial);
+    let other_idx = (0..graph.states.len())
+        .find(|&i| i != graph.initial)
+        .unwrap();
+    let other_dead = graph.is_dead_end(other_idx);
+
+    assert!(!initial_dead);
+    assert!(other_dead);
+}
+
+// ---------------------------------------------------------------------------
+// Truncation behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn truncation_sets_flag_instead_of_returning_error() {
+    // Build a chain longer than max_states so BFS cannot complete.
+    let actions: Vec<Action> = (0..50)
+        .map(|i| {
+            Action::new(format!("step_{i}"), 1.0)
+                .requires(if i == 0 {
+                    "start".to_string()
+                } else {
+                    format!("s_{}", i - 1)
+                })
+                .removes(if i == 0 {
+                    "start".to_string()
+                } else {
+                    format!("s_{}", i - 1)
+                })
+                .adds(format!("s_{i}"))
+        })
+        .collect();
+    let initial = State::from_facts(["start"]);
+    let graph = Planner::new(actions).with_max_states(5).explore(&initial);
+
+    assert!(graph.truncated);
+    // BFS stopped early; we should have at most max_states + a small buffer
+    // states discovered (the cap is checked at top of each iteration).
+    assert!(
+        graph.states.len() <= 10,
+        "expected ≤ 10 states under max_states=5, got {}",
+        graph.states.len()
+    );
+}
+
+#[test]
+fn no_truncation_when_state_space_fits() {
+    let actions = vec![
+        Action::new("ab", 1.0).requires("a").adds("b").removes("a"),
+        Action::new("bc", 1.0).requires("b").adds("c").removes("b"),
+    ];
+    let graph = Planner::new(actions)
+        .with_max_states(100)
+        .explore(&State::from_facts(["a"]));
+
+    assert!(!graph.truncated);
+    assert_eq!(graph.states.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural parity with plan()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_uses_same_graph_explore_returns() {
+    // explore_for_goal and plan should agree on whether the goal is reachable
+    // and on the cheapest cost via Dijkstra.
+    let actions = vec![
+        Action::new("cheap", 1.0).requires("a").adds("b"),
+        Action::new("expensive", 10.0).requires("a").adds("b"),
+        Action::new("finish", 1.0).requires("b").adds("done"),
+    ];
+    let initial = State::from_facts(["a"]);
+    let goal = Goal::new().requires("done");
+
+    let planner = Planner::new(actions);
+    let graph = planner.explore_for_goal(&initial, &goal);
+    let plan = planner.plan(&initial, &goal).unwrap().unwrap();
+
+    assert!(!graph.goal_satisfying.is_empty());
+    assert_eq!(plan.steps, vec!["cheap", "finish"]);
+    assert_eq!(plan.cost, 2.0);
+}

--- a/uncharles/README.md
+++ b/uncharles/README.md
@@ -25,17 +25,42 @@ cargo build -p uncharles --release
 
 ## Usage
 
+`uncharles` exposes two subcommands. The legacy flat form
+(`uncharles --config X`) still works — it is parsed as `uncharles run`.
+
+### `run` — sense, plan, optionally execute
+
 Plan a sequence and print it:
 
 ```sh
-cargo run -p uncharles -- --config uncharles/configs/deploy.yaml --pretty
+cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --pretty
 ```
 
 Execute the plan, re-sensing and replanning on divergence:
 
 ```sh
-cargo run -p uncharles -- --config uncharles/configs/deploy.yaml --execute --pretty
+cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --execute --pretty
 ```
+
+### `inspect` — visualise the state-action graph
+
+Load a config and print the static structure plus the bounded reachable
+state-action graph **without running any sensor or action commands**.
+Useful for debugging configs that produce no plan, surfacing typo'd fact
+names, orphan actions, unreachable goal facts, and dead-end states.
+
+```sh
+cargo run -p uncharles -- inspect --config uncharles/configs/deploy.yaml
+```
+
+The initial state is *simulated* — each sensor's `on_success` effects are
+applied in YAML declaration order without running anything. Use `--have
+<fact>` to layer additional facts on top, and `--max-states <N>` to override
+the planner's default exploration cap (10 000). Exit code is `0` when the
+config is clean, `1` when static analysis finds issues, `2` if the config
+could not be loaded.
+
+Implements [issue #22](https://github.com/leopepe/automata-atelier/issues/22).
 
 A minimal config:
 

--- a/uncharles/src/inspect.rs
+++ b/uncharles/src/inspect.rs
@@ -1,0 +1,696 @@
+//! `uncharles inspect` — load a YAML config and print the static structure
+//! plus the bounded reachable state-action graph, without running any
+//! sensors or actions.
+//!
+//! See `docs/issues.md` for the design rationale; this is the implementation
+//! of issue #22 (subcommand for visual debugging of configs).
+//!
+//! No commands run. The "initial state" used to seed exploration is
+//! *simulated* by applying each sensor's `on_success` effects in declaration
+//! order, plus any extra facts from `--have <fact>`. This produces a
+//! deterministic starting state derived from the config alone — useful for
+//! "what would the planner see if every sensor reported success?" debugging
+//! without the side effects of actually running the sensors.
+
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+use goap_planner::{Goal, Planner, State, StateGraph};
+
+use crate::config::{ActionSpec, Config, GoalSpec, SensorSpec};
+use crate::run::{build_actions, build_goal};
+
+/// Construct a planner-ready initial state from a config without running
+/// anything: apply each sensor's `on_success` effects in YAML declaration
+/// order, then layer the extra `have` facts on top.
+///
+/// This is the "best-case" simulation: every sensor is treated as if it
+/// returned success. It is *not* what the live runtime would see — for
+/// that, run `uncharles run` (which actually executes sensor commands).
+pub fn simulate_initial_state(config: &Config, extra_have: &[String]) -> State {
+    let mut state = State::new();
+    for sensor in &config.sensors {
+        let effects = sensor.effects_for(true);
+        for fact in &effects.add {
+            state.insert(fact);
+        }
+        for fact in &effects.remove {
+            state.remove(fact);
+        }
+    }
+    for fact in extra_have {
+        state.insert(fact);
+    }
+    state
+}
+
+/// Static-analysis findings for a config — issues that don't depend on the
+/// state-space graph and can be derived from the spec lists alone, plus
+/// dead-end states that fall out of the explored graph.
+pub struct StaticAnalysis {
+    /// Action names whose preconditions reference a fact no producer
+    /// (sensor's `on_success.add` or another action's `adds`) can produce.
+    /// The fact is the offending one.
+    pub orphan_actions: Vec<(String, String)>,
+    /// Goal-required facts that no producer can produce. Same shape as
+    /// orphan actions, but for the goal.
+    pub unreachable_goal_facts: Vec<String>,
+    /// Indices into `StateGraph::states` for states with no outgoing edges
+    /// that don't satisfy the goal — places exploration ran out of moves
+    /// without succeeding.
+    pub dead_end_states: Vec<usize>,
+}
+
+impl StaticAnalysis {
+    pub fn is_clean(&self) -> bool {
+        self.orphan_actions.is_empty()
+            && self.unreachable_goal_facts.is_empty()
+            && self.dead_end_states.is_empty()
+    }
+}
+
+/// Run all three static analyses against a config and an explored graph.
+pub fn analyse(config: &Config, graph: &StateGraph) -> StaticAnalysis {
+    let producers = collect_producers(&config.sensors, &config.actions);
+
+    let orphan_actions: Vec<(String, String)> = config
+        .actions
+        .iter()
+        .flat_map(|a| {
+            a.requires
+                .iter()
+                .filter(|fact| !producers.contains(*fact))
+                .map(|fact| (a.name.clone(), fact.clone()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let unreachable_goal_facts: Vec<String> = config
+        .goal
+        .requires
+        .iter()
+        .filter(|fact| !producers.contains(*fact))
+        .cloned()
+        .collect();
+
+    let goal_set: BTreeSet<usize> = graph.goal_satisfying.iter().copied().collect();
+    let mut dead_end_states: Vec<usize> = (0..graph.states.len())
+        .filter(|i| graph.is_dead_end(*i) && !goal_set.contains(i))
+        .collect();
+    dead_end_states.sort();
+
+    StaticAnalysis {
+        orphan_actions,
+        unreachable_goal_facts,
+        dead_end_states,
+    }
+}
+
+/// The set of facts any producer (a sensor's `on_success` add list or an
+/// action's `adds` list) can introduce. Used by `analyse` to detect
+/// preconditions and goal-required facts with no source.
+fn collect_producers(sensors: &[SensorSpec], actions: &[ActionSpec]) -> BTreeSet<String> {
+    let mut set = BTreeSet::new();
+    for s in sensors {
+        for fact in &s.effects_for(true).add {
+            set.insert(fact.clone());
+        }
+    }
+    for a in actions {
+        for fact in &a.adds {
+            set.insert(fact.clone());
+        }
+    }
+    set
+}
+
+/// Render a complete inspection report as plain text. Composed of:
+///
+/// 1. Sensors — name, effects on success/failure.
+/// 2. Actions — preconditions, effects, costs.
+/// 3. Goal — required and forbidden facts.
+/// 4. Initial state — simulated, with note about how it was derived.
+/// 5. State-action graph — every reachable state with outgoing edges.
+/// 6. Static analysis — orphans, unreachable goal facts, dead-ends.
+pub fn render_text(
+    config: &Config,
+    initial: &State,
+    graph: &StateGraph,
+    analysis: &StaticAnalysis,
+) -> String {
+    let mut out = String::new();
+    render_sensors(&mut out, &config.sensors);
+    render_actions(&mut out, &config.actions);
+    render_goal(&mut out, &config.goal);
+    render_initial_state(&mut out, initial);
+    render_state_graph(&mut out, graph);
+    render_analysis(&mut out, analysis, graph);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Section renderers
+// ---------------------------------------------------------------------------
+
+fn render_sensors(out: &mut String, sensors: &[SensorSpec]) {
+    let _ = writeln!(out, "== sensors ({}) ==", sensors.len());
+    if sensors.is_empty() {
+        let _ = writeln!(out, "  (none)");
+    }
+    for s in sensors {
+        let success = s.effects_for(true);
+        let failure = s.effects_for(false);
+        let _ = writeln!(out, "  {}", s.name);
+        let _ = writeln!(out, "    cmd:        {}", s.cmd.join(" "));
+        let _ = writeln!(
+            out,
+            "    on success: {}",
+            format_effects(&success.add, &success.remove)
+        );
+        let _ = writeln!(
+            out,
+            "    on failure: {}",
+            format_effects(&failure.add, &failure.remove)
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn render_actions(out: &mut String, actions: &[ActionSpec]) {
+    let _ = writeln!(out, "== actions ({}) ==", actions.len());
+    if actions.is_empty() {
+        let _ = writeln!(out, "  (none)");
+    }
+    for a in actions {
+        let _ = writeln!(out, "  {} [cost {}]", a.name, a.cost);
+        let _ = writeln!(out, "    requires: {}", join_or_none(&a.requires));
+        let _ = writeln!(out, "    adds:     {}", join_or_none(&a.adds));
+        let _ = writeln!(out, "    removes:  {}", join_or_none(&a.removes));
+    }
+    let _ = writeln!(out);
+}
+
+fn render_goal(out: &mut String, goal: &GoalSpec) {
+    let _ = writeln!(out, "== goal ==");
+    let _ = writeln!(out, "  requires: {}", join_or_none(&goal.requires));
+    let _ = writeln!(out, "  forbids:  {}", join_or_none(&goal.forbids));
+    let _ = writeln!(out);
+}
+
+fn render_initial_state(out: &mut String, initial: &State) {
+    let _ = writeln!(out, "== initial state (simulated) ==");
+    let _ = writeln!(
+        out,
+        "  derived by applying each sensor's on_success effects in declaration"
+    );
+    let _ = writeln!(
+        out,
+        "  order, then any --have facts. No sensor commands were run."
+    );
+    let mut facts: Vec<String> = initial.facts().map(String::from).collect();
+    facts.sort();
+    if facts.is_empty() {
+        let _ = writeln!(out, "  facts: (empty)");
+    } else {
+        let _ = writeln!(out, "  facts: {}", facts.join(", "));
+    }
+    let _ = writeln!(out);
+}
+
+fn render_state_graph(out: &mut String, graph: &StateGraph) {
+    let goal_set: BTreeSet<usize> = graph.goal_satisfying.iter().copied().collect();
+    let _ = writeln!(out, "== state-action graph ==");
+    let _ = writeln!(
+        out,
+        "  {} states, {} transitions, {} goal-satisfying{}",
+        graph.states.len(),
+        graph.edges.len(),
+        graph.goal_satisfying.len(),
+        if graph.truncated {
+            " (TRUNCATED — max_states reached)"
+        } else {
+            ""
+        }
+    );
+    let _ = writeln!(out);
+
+    for (i, node) in graph.states.iter().enumerate() {
+        let mut tags: Vec<&str> = Vec::new();
+        if i == graph.initial {
+            tags.push("initial");
+        }
+        if goal_set.contains(&i) {
+            tags.push("goal ✓");
+        }
+        let suffix = if tags.is_empty() {
+            String::new()
+        } else {
+            format!("  ({})", tags.join(", "))
+        };
+        let _ = writeln!(out, "  S{i} = {}{}", format_facts(&node.facts), suffix);
+
+        let mut out_edges: Vec<_> = graph.outgoing(i).collect();
+        out_edges.sort_by(|a, b| a.action.cmp(&b.action));
+        for e in out_edges {
+            let _ = writeln!(out, "    → {} [{}] → S{}", e.action, e.cost, e.to);
+        }
+    }
+    let _ = writeln!(out);
+}
+
+fn render_analysis(out: &mut String, analysis: &StaticAnalysis, graph: &StateGraph) {
+    let _ = writeln!(out, "== static analysis ==");
+    if analysis.is_clean() {
+        let _ = writeln!(out, "  ✓ no orphan actions");
+        let _ = writeln!(out, "  ✓ no unreachable goal facts");
+        let _ = writeln!(out, "  ✓ no dead-end states");
+        return;
+    }
+
+    if analysis.orphan_actions.is_empty() {
+        let _ = writeln!(out, "  ✓ no orphan actions");
+    } else {
+        let _ = writeln!(
+            out,
+            "  ✗ orphan actions ({}):",
+            analysis.orphan_actions.len()
+        );
+        for (action, fact) in &analysis.orphan_actions {
+            let _ = writeln!(
+                out,
+                "    - `{action}` requires `{fact}` but no sensor or action produces it"
+            );
+        }
+    }
+
+    if analysis.unreachable_goal_facts.is_empty() {
+        let _ = writeln!(out, "  ✓ no unreachable goal facts");
+    } else {
+        let _ = writeln!(
+            out,
+            "  ✗ unreachable goal facts ({}):",
+            analysis.unreachable_goal_facts.len()
+        );
+        for fact in &analysis.unreachable_goal_facts {
+            let _ = writeln!(out, "    - `{fact}` has no producer");
+        }
+    }
+
+    if analysis.dead_end_states.is_empty() {
+        let _ = writeln!(out, "  ✓ no dead-end states");
+    } else {
+        let _ = writeln!(
+            out,
+            "  ✗ dead-end states ({}):",
+            analysis.dead_end_states.len()
+        );
+        for &i in &analysis.dead_end_states {
+            let _ = writeln!(
+                out,
+                "    - S{i} = {} (no applicable actions, not goal-satisfying)",
+                format_facts(&graph.states[i].facts)
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn join_or_none(items: &[String]) -> String {
+    if items.is_empty() {
+        "(none)".to_string()
+    } else {
+        items.join(", ")
+    }
+}
+
+fn format_effects(add: &[String], remove: &[String]) -> String {
+    let mut parts = Vec::new();
+    for f in add {
+        parts.push(format!("+{f}"));
+    }
+    for f in remove {
+        parts.push(format!("-{f}"));
+    }
+    if parts.is_empty() {
+        "(no effect)".to_string()
+    } else {
+        parts.join(", ")
+    }
+}
+
+fn format_facts(facts: &BTreeSet<String>) -> String {
+    if facts.is_empty() {
+        "{}".to_string()
+    } else {
+        let joined: Vec<&str> = facts.iter().map(String::as_str).collect();
+        format!("{{{}}}", joined.join(", "))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level driver
+// ---------------------------------------------------------------------------
+
+/// Build the full inspection report for a config: simulate the initial
+/// state, run [`Planner::explore_for_goal`], compute static analysis, and
+/// return everything ready for rendering.
+///
+/// `max_states` overrides the planner's default cap; `None` uses the
+/// default (10 000).
+pub fn inspect(
+    config: &Config,
+    extra_have: &[String],
+    max_states: Option<usize>,
+) -> (State, StateGraph, StaticAnalysis) {
+    let initial = simulate_initial_state(config, extra_have);
+    let actions = build_actions(&config.actions);
+    let goal: Goal = build_goal(&config.goal);
+
+    let mut planner = Planner::new(actions);
+    if let Some(cap) = max_states {
+        planner = planner.with_max_states(cap);
+    }
+    let graph = planner.explore_for_goal(&initial, &goal);
+    let analysis = analyse(config, &graph);
+    (initial, graph, analysis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Effects;
+
+    fn config(yaml: &str) -> Config {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // simulate_initial_state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn simulate_applies_each_sensor_default_on_success_add() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+              - name: b
+                cmd: ["true"]
+            actions: []
+            goal:
+              requires: [done]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let mut facts: Vec<String> = initial.facts().map(String::from).collect();
+        facts.sort();
+        assert_eq!(facts, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn simulate_respects_explicit_on_success_effects() {
+        let c = config(
+            r#"
+            sensors:
+              - name: build
+                cmd: ["cargo", "build"]
+                on_success:
+                  add: [built, fresh]
+                  remove: [stale]
+            actions: []
+            goal:
+              requires: [done]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let mut facts: Vec<String> = initial.facts().map(String::from).collect();
+        facts.sort();
+        // Only `built` and `fresh` were added; `stale` was never present so
+        // the remove is a no-op.
+        assert_eq!(facts, vec!["built", "fresh"]);
+    }
+
+    #[test]
+    fn simulate_layers_extra_have_facts_on_top() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions: []
+            goal:
+              requires: [done]
+            "#,
+        );
+        let extra = vec!["foo".to_string(), "bar".to_string()];
+        let initial = simulate_initial_state(&c, &extra);
+        let mut facts: Vec<String> = initial.facts().map(String::from).collect();
+        facts.sort();
+        assert_eq!(facts, vec!["a", "bar", "foo"]);
+    }
+
+    #[test]
+    fn simulate_with_no_sensors_and_no_have_yields_empty_state() {
+        let c = config(
+            r#"
+            sensors: []
+            actions:
+              - name: noop
+                cost: 1.0
+                cmd: ["true"]
+            goal:
+              requires: [done]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        assert!(initial.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // analyse — orphan actions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn analyse_flags_orphan_actions() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: needs_b
+                cost: 1.0
+                requires: [b]
+                adds: [c]
+                cmd: ["true"]
+            goal:
+              requires: [c]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let actions = build_actions(&c.actions);
+        let goal = build_goal(&c.goal);
+        let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+        let analysis = analyse(&c, &graph);
+
+        assert_eq!(analysis.orphan_actions.len(), 1);
+        assert_eq!(analysis.orphan_actions[0].0, "needs_b");
+        assert_eq!(analysis.orphan_actions[0].1, "b");
+    }
+
+    #[test]
+    fn analyse_recognises_action_chain_as_producer() {
+        // a-action produces b; b-action requires b. Not orphan.
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: a_action
+                cost: 1.0
+                requires: [a]
+                adds: [b]
+                cmd: ["true"]
+              - name: b_action
+                cost: 1.0
+                requires: [b]
+                adds: [c]
+                cmd: ["true"]
+            goal:
+              requires: [c]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let actions = build_actions(&c.actions);
+        let goal = build_goal(&c.goal);
+        let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+        let analysis = analyse(&c, &graph);
+
+        assert!(analysis.orphan_actions.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // analyse — unreachable goal facts
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn analyse_flags_unreachable_goal_facts() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: act
+                cost: 1.0
+                requires: [a]
+                adds: [b]
+                cmd: ["true"]
+            goal:
+              requires: [unreachable]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let actions = build_actions(&c.actions);
+        let goal = build_goal(&c.goal);
+        let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+        let analysis = analyse(&c, &graph);
+
+        assert_eq!(analysis.unreachable_goal_facts, vec!["unreachable"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // analyse — clean config
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn analyse_clean_config_is_clean() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: act
+                cost: 1.0
+                requires: [a]
+                adds: [done]
+                removes: [a]
+                cmd: ["true"]
+            goal:
+              requires: [done]
+            "#,
+        );
+        let initial = simulate_initial_state(&c, &[]);
+        let actions = build_actions(&c.actions);
+        let goal = build_goal(&c.goal);
+        let graph = Planner::new(actions).explore_for_goal(&initial, &goal);
+        let analysis = analyse(&c, &graph);
+
+        assert!(analysis.is_clean());
+    }
+
+    // -----------------------------------------------------------------------
+    // render_text — smoke check on shape
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn render_text_includes_all_sections() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: act
+                cost: 1.0
+                requires: [a]
+                adds: [done]
+                removes: [a]
+                cmd: ["true"]
+            goal:
+              requires: [done]
+            "#,
+        );
+        let (initial, graph, analysis) = inspect(&c, &[], None);
+        let text = render_text(&c, &initial, &graph, &analysis);
+
+        assert!(text.contains("== sensors ("));
+        assert!(text.contains("== actions ("));
+        assert!(text.contains("== goal =="));
+        assert!(text.contains("== initial state"));
+        assert!(text.contains("== state-action graph =="));
+        assert!(text.contains("== static analysis =="));
+    }
+
+    #[test]
+    fn render_text_marks_initial_and_goal_states() {
+        let c = config(
+            r#"
+            sensors:
+              - name: a
+                cmd: ["true"]
+            actions:
+              - name: act
+                cost: 1.0
+                requires: [a]
+                adds: [done]
+                removes: [a]
+                cmd: ["true"]
+            goal:
+              requires: [done]
+            "#,
+        );
+        let (initial, graph, analysis) = inspect(&c, &[], None);
+        let text = render_text(&c, &initial, &graph, &analysis);
+
+        assert!(text.contains("(initial)"));
+        assert!(text.contains("goal ✓"));
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers (small)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_effects_lists_adds_and_removes() {
+        let s = format_effects(&["x".into(), "y".into()], &["z".into()]);
+        assert_eq!(s, "+x, +y, -z");
+    }
+
+    #[test]
+    fn format_effects_no_effect_when_empty() {
+        let s = format_effects(&[], &[]);
+        assert_eq!(s, "(no effect)");
+    }
+
+    #[test]
+    fn collect_producers_unions_sensor_adds_and_action_adds() {
+        let sensors = vec![SensorSpec {
+            name: "ready".into(),
+            cmd: vec!["true".into()],
+            on_success: Some(Effects {
+                add: vec!["a".into(), "b".into()],
+                remove: vec![],
+            }),
+            on_failure: None,
+        }];
+        let actions = vec![ActionSpec {
+            name: "act".into(),
+            cost: 1.0,
+            requires: vec![],
+            adds: vec!["c".into()],
+            removes: vec![],
+            cmd: None,
+            on_failure: None,
+        }];
+        let producers = collect_producers(&sensors, &actions);
+        let v: Vec<_> = producers.into_iter().collect();
+        assert_eq!(v, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+}

--- a/uncharles/src/main.rs
+++ b/uncharles/src/main.rs
@@ -2,12 +2,17 @@
 //! YAML config. Named after the obsessive task-list-driven robot from
 //! Adrian Tchaikovsky's *Service Model*.
 //!
-//! Default mode is one-shot: load the config, run sensors, plan, print the
-//! plan, exit. Pass `--execute` to switch into the persistent loop that
-//! actually runs each action's `cmd`, re-senses, and replans until the
-//! goal is satisfied (or something goes wrong).
+//! Subcommands:
+//!
+//! - `run` — load the config, run sensors, plan, and (with `--execute`)
+//!   actually run the plan. The default subcommand for backward compatibility
+//!   — `uncharles --config X` is parsed as `uncharles run --config X`.
+//! - `inspect` — load the config and print the static structure plus the
+//!   bounded reachable state-action graph, *without* running sensors or
+//!   actions. For visual debugging.
 
 mod config;
+mod inspect;
 mod run;
 
 use std::fs;
@@ -16,7 +21,7 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 
 use config::Config;
 use run::{LoopEvent, LoopOutcome, Outcome, RunError, run_loop, sense_and_plan};
@@ -27,6 +32,24 @@ use run::{LoopEvent, LoopOutcome, Outcome, RunError, run_loop, sense_and_plan};
     about = "Sense → plan → act loop driving goap-planner from a YAML config"
 )]
 struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run the sense → plan → act loop. Optionally executes actions
+    /// (`--execute`) and replans on divergence.
+    Run(RunArgs),
+    /// Inspect a config: print the sensors, actions, goal, simulated initial
+    /// state, the bounded reachable state-action graph, and a static-analysis
+    /// section flagging orphan actions, unreachable goal facts, and dead-end
+    /// states. Does not run any sensor or action commands.
+    Inspect(InspectArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+struct RunArgs {
     /// Path to the YAML config describing sensors, actions, and the goal.
     #[arg(short, long)]
     config: PathBuf,
@@ -63,13 +86,66 @@ struct Cli {
     dry_run: bool,
 }
 
-fn main() -> ExitCode {
-    let cli = Cli::parse();
+#[derive(Args, Debug)]
+struct InspectArgs {
+    /// Path to the YAML config to inspect.
+    #[arg(short, long)]
+    config: PathBuf,
 
-    let raw = match fs::read_to_string(&cli.config) {
+    /// Extra facts to layer on top of the simulated initial state. Useful
+    /// for "what does the planner see if I assume fact X is also true?".
+    #[arg(long, value_name = "FACT")]
+    have: Vec<String>,
+
+    /// Override the planner's `max_states` cap on state-space exploration.
+    /// When the cap is hit, the printed graph is marked TRUNCATED.
+    #[arg(long, value_name = "N")]
+    max_states: Option<usize>,
+}
+
+fn main() -> ExitCode {
+    // Backward compatibility: if the first arg is not a known subcommand or
+    // a help/version flag, insert "run" implicitly so `uncharles --config X`
+    // continues to work.
+    let argv = bridge_legacy_argv(std::env::args().collect());
+    let cli = Cli::parse_from(argv);
+
+    match cli.command {
+        Command::Run(args) => run_command(args),
+        Command::Inspect(args) => inspect_command(args),
+    }
+}
+
+/// If the first argument looks like a flag (starts with `-`) rather than a
+/// known subcommand, splice in `run` so the historical flat CLI keeps
+/// working: `uncharles --config X` → `uncharles run --config X`.
+fn bridge_legacy_argv(argv: Vec<String>) -> Vec<String> {
+    if argv.len() < 2 {
+        return argv;
+    }
+    let first = argv[1].as_str();
+    let known = ["run", "inspect", "help", "-h", "--help", "-V", "--version"];
+    if known.contains(&first) {
+        return argv;
+    }
+    // Anything else (most importantly, anything starting with `-`) is treated
+    // as legacy run-mode argv. Insert `run` in front of the first user arg.
+    let mut bridged = Vec::with_capacity(argv.len() + 1);
+    bridged.push(argv[0].clone());
+    bridged.push("run".to_string());
+    bridged.extend(argv.into_iter().skip(1));
+    bridged
+}
+
+// ---------------------------------------------------------------------------
+// `run` subcommand — the existing sense → plan → act behaviour
+// ---------------------------------------------------------------------------
+
+fn run_command(args: RunArgs) -> ExitCode {
+    let raw = match fs::read_to_string(&args.config) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("error: cannot read {}: {e}", cli.config.display());
+            eprintln!("error: cannot read {}: {e}", args.config.display());
             return ExitCode::from(2);
         }
     };
@@ -82,31 +158,31 @@ fn main() -> ExitCode {
         }
     };
 
-    if cli.dry_run {
-        emit_dry_run(&config, cli.pretty);
+    if args.dry_run {
+        emit_dry_run(&config, args.pretty);
         return ExitCode::SUCCESS;
     }
 
-    if cli.execute {
-        return run_execute_mode(&cli, &config);
+    if args.execute {
+        return run_execute_mode(&args, &config);
     }
 
-    match sense_and_plan(&config, cli.have) {
+    match sense_and_plan(&config, args.have) {
         Ok(outcome) => {
-            emit_outcome(&outcome, cli.pretty);
+            emit_outcome(&outcome, args.pretty);
             match outcome.plan {
                 Some(_) => ExitCode::SUCCESS,
                 None => ExitCode::from(1),
             }
         }
         Err(e) => {
-            emit_error(&e, cli.pretty);
+            emit_error(&e, args.pretty);
             ExitCode::from(2)
         }
     }
 }
 
-fn run_execute_mode(cli: &Cli, config: &Config) -> ExitCode {
+fn run_execute_mode(args: &RunArgs, config: &Config) -> ExitCode {
     let interrupted = Arc::new(AtomicBool::new(false));
     let signal_flag = Arc::clone(&interrupted);
     if let Err(e) = ctrlc::set_handler(move || {
@@ -116,12 +192,12 @@ fn run_execute_mode(cli: &Cli, config: &Config) -> ExitCode {
         return ExitCode::from(2);
     }
 
-    let pretty = cli.pretty;
+    let pretty = args.pretty;
     let result = run_loop(
         config,
-        cli.have.clone(),
-        cli.max_iterations,
-        cli.interval_ms,
+        args.have.clone(),
+        args.max_iterations,
+        args.interval_ms,
         Arc::clone(&interrupted),
         |event| emit_event(&event, pretty),
     );
@@ -143,6 +219,46 @@ fn run_execute_mode(cli: &Cli, config: &Config) -> ExitCode {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// `inspect` subcommand — issue #22
+// ---------------------------------------------------------------------------
+
+fn inspect_command(args: InspectArgs) -> ExitCode {
+    let raw = match fs::read_to_string(&args.config) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: cannot read {}: {e}", args.config.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    let config: Config = match serde_yaml::from_str(&raw) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: invalid config: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let (initial, graph, analysis) = inspect::inspect(&config, &args.have, args.max_states);
+    let report = inspect::render_text(&config, &initial, &graph, &analysis);
+    print!("{report}");
+
+    if analysis.is_clean() {
+        ExitCode::SUCCESS
+    } else {
+        // Static-analysis findings still produce a useful report; surface
+        // them via a non-zero exit so `uncharles inspect` is usable as a
+        // lint pass in scripts. Exit code 1 means "issues found", distinct
+        // from 2 ("could not run").
+        ExitCode::from(1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Existing emitters (unchanged)
+// ---------------------------------------------------------------------------
 
 fn emit_dry_run(config: &Config, pretty: bool) {
     let v = serde_json::json!({

--- a/uncharles/tests/inspect.rs
+++ b/uncharles/tests/inspect.rs
@@ -1,0 +1,209 @@
+//! End-to-end tests for the `uncharles inspect` subcommand.
+//!
+//! Run the compiled binary against the checked-in smoke configs (no shell
+//! side effects) and assert on the human-readable report produced.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_uncharles")
+}
+
+fn config_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("configs")
+        .join(name)
+}
+
+#[test]
+fn inspect_prints_all_sections_for_smoke_loop() {
+    let output = Command::new(binary())
+        .args(["inspect", "--config"])
+        .arg(config_path("smoke_loop.yaml"))
+        .output()
+        .expect("failed to spawn uncharles inspect");
+    assert!(
+        output.status.success(),
+        "expected exit 0 (clean config), got {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // All six sections present.
+    assert!(stdout.contains("== sensors ("));
+    assert!(stdout.contains("== actions ("));
+    assert!(stdout.contains("== goal =="));
+    assert!(stdout.contains("== initial state"));
+    assert!(stdout.contains("== state-action graph =="));
+    assert!(stdout.contains("== static analysis =="));
+
+    // Static analysis on a clean config should pass.
+    assert!(stdout.contains("✓ no orphan actions"));
+    assert!(stdout.contains("✓ no unreachable goal facts"));
+    assert!(stdout.contains("✓ no dead-end states"));
+
+    // The smoke-loop config has 1 sensor, 3 actions, and the planner's plan
+    // is do_a → do_b → do_c, so the graph should have 4 reachable states.
+    assert!(stdout.contains("(initial)"));
+    assert!(stdout.contains("goal ✓"));
+    assert!(stdout.contains("do_a"));
+    assert!(stdout.contains("do_b"));
+    assert!(stdout.contains("do_c"));
+}
+
+#[test]
+fn inspect_does_not_run_sensor_or_action_commands() {
+    // Smoke-loop's sensors and actions all use `true`, but we use a marker
+    // file to confirm: if a command had run, this file would exist.
+    // We pass a config that never executes anything (and the smoke configs
+    // don't either), and verify the inspect run never blocks waiting for
+    // anything that needs IO. The simplest proof: the run finishes very
+    // fast and the report lands.
+    let start = std::time::Instant::now();
+    let output = Command::new(binary())
+        .args(["inspect", "--config"])
+        .arg(config_path("smoke_loop.yaml"))
+        .output()
+        .expect("failed to spawn uncharles inspect");
+    let elapsed = start.elapsed();
+
+    assert!(output.status.success());
+    // Inspection is purely in-memory after YAML parse; should finish in
+    // well under a second on any reasonable machine.
+    assert!(
+        elapsed.as_secs() < 5,
+        "inspect took {elapsed:?}, much longer than expected for an in-memory run"
+    );
+
+    // The "initial state (simulated)" header is the user-visible signal
+    // that no sensors ran.
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("== initial state (simulated) =="),
+        "expected the 'simulated' label on the initial-state section to make it explicit that sensors did not run"
+    );
+    assert!(stdout.contains("No sensor commands were run."));
+}
+
+#[test]
+fn inspect_have_flag_layers_extra_facts_on_initial_state() {
+    let output = Command::new(binary())
+        .args(["inspect", "--config"])
+        .arg(config_path("smoke_loop.yaml"))
+        .args(["--have", "extra_fact"])
+        .output()
+        .expect("failed to spawn uncharles inspect");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // The `--have` flag should put `extra_fact` into the simulated initial state.
+    assert!(
+        stdout.contains("extra_fact"),
+        "expected --have to layer the fact onto the initial state\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn inspect_flags_orphan_actions_with_nonzero_exit() {
+    // smoke_failure.yaml is checked in for failure-recovery tests, but
+    // we want a config with an orphan action specifically. Build one
+    // ad-hoc via a temp file.
+    let tmp = std::env::temp_dir().join("uncharles_inspect_orphan.yaml");
+    std::fs::write(
+        &tmp,
+        r#"
+sensors: []
+actions:
+  - name: needs_unobtainium
+    cost: 1.0
+    requires: [unobtainium]
+    adds: [done]
+    cmd: ["true"]
+goal:
+  requires: [done]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(binary())
+        .args(["inspect", "--config"])
+        .arg(&tmp)
+        .output()
+        .expect("failed to spawn uncharles inspect");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("✗ orphan actions"),
+        "expected orphan-action callout\nstdout:\n{stdout}"
+    );
+    assert!(stdout.contains("needs_unobtainium"));
+    assert!(stdout.contains("unobtainium"));
+
+    // Issues found → exit code 1 (distinct from 2 = couldn't run).
+    let code = output
+        .status
+        .code()
+        .expect("expected normal exit, not signal");
+    assert_eq!(code, 1, "exit 1 on issues found, got {code}");
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+fn inspect_flags_unreachable_goal_facts() {
+    let tmp = std::env::temp_dir().join("uncharles_inspect_unreachable_goal.yaml");
+    std::fs::write(
+        &tmp,
+        r#"
+sensors:
+  - name: ready
+    cmd: ["true"]
+actions:
+  - name: act
+    cost: 1.0
+    requires: [ready]
+    adds: [partially_done]
+    cmd: ["true"]
+goal:
+  requires: [fully_done]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(binary())
+        .args(["inspect", "--config"])
+        .arg(&tmp)
+        .output()
+        .expect("failed to spawn uncharles inspect");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("✗ unreachable goal facts"),
+        "expected unreachable-goal callout\nstdout:\n{stdout}"
+    );
+    assert!(stdout.contains("fully_done"));
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+fn legacy_flat_cli_still_works_via_run_bridge() {
+    // `uncharles --config X` should be parsed as `uncharles run --config X`
+    // for backward compat with existing scripts and tests.
+    let output = Command::new(binary())
+        .arg("--config")
+        .arg(config_path("smoke_loop.yaml"))
+        .output()
+        .expect("failed to spawn legacy-style uncharles");
+    assert!(
+        output.status.success(),
+        "legacy `uncharles --config X` should still produce a plan; got {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed["ok"], true);
+}


### PR DESCRIPTION
Closes #22.

## Summary

- New `uncharles inspect` subcommand that loads a YAML config and prints the static structure plus the bounded reachable state-action graph **without running any sensor or action commands** — for visual debugging when a config produces no plan.
- New public API in `goap-planner`: `Planner::explore` (goal-agnostic) and `Planner::explore_for_goal` (records goal-satisfying states), both returning a stable-ordered `StateGraph`. `Planner::plan` now delegates to `explore_for_goal` internally; existing behaviour and `PlannerError::StateSpaceLimitExceeded` semantics are preserved.
- The CLI is refactored to clap subcommands (`run` and `inspect`), with a small backward-compat shim that keeps the legacy flat form `uncharles --config X` working — it parses as `uncharles run --config X`.

The `text` output format and the static-analysis section ship in this PR; `dot` / `mermaid` / `json` formats are deferred to a follow-up per the build order in #22.

## What `inspect` produces

Six sections: **sensors** (name, command, on-success/on-failure effects), **actions** (preconditions / effects / cost), **goal**, **initial state** (simulated by applying each sensor's `on_success` effects — the file makes the simulation explicit), **state-action graph** (every reachable state with its outgoing edges, initial and goal-satisfying states marked), and **static analysis** (orphan actions, unreachable goal facts, dead-end states).

Sample output against the existing `smoke_loop.yaml` (clean config):

```
== sensors (1) ==
  heartbeat
    cmd:        true
    on success: +heartbeat
    on failure: -heartbeat

== actions (3) ==
  do_a [cost 1]
    requires: heartbeat
    adds:     a_done
    removes:  (none)
  ...

== state-action graph ==
  4 states, 6 transitions, 1 goal-satisfying

  S0 = {a_done, b_done, finished, heartbeat}  (goal ✓)
    → do_a [1] → S0
  S1 = {a_done, b_done, heartbeat}
    → do_a [1] → S1
    → do_c [1] → S0
  S2 = {a_done, heartbeat}
    → do_a [1] → S2
    → do_b [1] → S1
  S3 = {heartbeat}  (initial)
    → do_a [1] → S2

== static analysis ==
  ✓ no orphan actions
  ✓ no unreachable goal facts
  ✓ no dead-end states
```

For a config with an action that requires a fact no one produces:

```
== static analysis ==
  ✗ orphan actions (1):
    - `needs_unobtainium` requires `unobtainium` but no sensor or action produces it
  ✓ no unreachable goal facts
  ✓ no dead-end states
```

Exit codes: `0` when clean, `1` when static analysis finds issues (so it's usable as a lint pass in scripts), `2` when the config could not be loaded.

## CLI changes

```sh
# new
uncharles run --config X.yaml [...flags...]
uncharles inspect --config X.yaml [--have FACT...] [--max-states N]

# still works (legacy flat form, parsed as "run")
uncharles --config X.yaml [...flags...]
```

The legacy bridge sits in `bridge_legacy_argv` in `main.rs` — if `argv[1]` doesn't match a known subcommand or `-h`/`--help`/`-V`/`--version`, `run` is spliced in front of the user's args. Existing integration tests (which use the flat form) continue to pass; a new test (`legacy_flat_cli_still_works_via_run_bridge`) pins the bridge.

## `Planner::explore` shape

```rust
impl Planner {
    pub fn explore(&self, initial: &State) -> StateGraph;
    pub fn explore_for_goal(&self, initial: &State, goal: &Goal) -> StateGraph;
}

pub struct StateGraph {
    pub states: Vec<StateNode>,         // sorted by signature
    pub edges: Vec<StateEdge>,          // sorted by (from, action, to)
    pub initial: usize,
    pub goal_satisfying: Vec<usize>,
    pub truncated: bool,
}
```

Neither function returns `Result` — `truncated` replaces the error path so partial graphs are still inspectable. `Planner::plan` keeps its existing error contract by checking `truncated` after the call.

## Conventional commit

Type:

- [x] `feat` — new user-visible capability
- [ ] `fix`
- [ ] `docs`
- [ ] `style`
- [ ] `refactor`
- [ ] `perf`
- [ ] `test`
- [ ] `build`
- [ ] `ci`
- [ ] `chore`
- [ ] `revert`

Scope: `uncharles` (and `goap-planner` for the public-API addition)

## Breaking changes

None. The CLI surface gains subcommands but the legacy flat form is preserved by `bridge_legacy_argv`. `Planner::plan`'s contract (signatures, return types, error variants) is unchanged.

## Test plan

- [x] `cargo fmt --all` (clean via `--check`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — all pass, including 4 new doctests, 14 new integration tests in `goap-planner/tests/explore.rs`, 6 new integration tests in `uncharles/tests/inspect.rs`, and 13 new unit tests inside `uncharles/src/inspect.rs`.
- [x] Manual: ran `cargo run -p uncharles -- inspect --config uncharles/configs/smoke_loop.yaml` and confirmed the output reads as expected.

## Linked issues

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)