### PR TITLE
fix(ci): pin same-machine bench comparisons + harden flaky micro-benches

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -81,47 +81,24 @@ jobs:
             echo "::notice::No bench suite on origin/${{ github.base_ref }} for ${{ matrix.crate }} — this PR introduces it; comparison gate skipped."
           fi
 
-      - name: Restore base-branch baseline cache
-        # Try to reuse a base-branch bench result captured by an earlier
-        # PR against the same base SHA. The baseline is a property of
-        # `<crate>` × `<base sha>` and is identical across PRs — running
-        # it again is wasted CI minutes.
-        #
-        # The cache stores criterion's `pr-base` baseline data (under
-        # `target/criterion`) and the raw log so the artifact upload at
-        # the end of the job still surfaces it. Cache misses naturally
-        # whenever the base branch moves.
-        id: cache-base
-        if: steps.baseline-check.outputs.available == 'true'
-        uses: actions/cache/restore@v4
-        with:
-          key: bench-base-v3-${{ matrix.crate }}-${{ steps.base-sha.outputs.sha }}
-          path: |
-            target/criterion
-            bench-base.txt
-
       - name: Save base-branch baseline
-        # Cache-miss path: bench origin/<base_ref> and save it as
-        # `pr-base`. Criterion baselines are stored in `target/criterion`
-        # and survive the checkout back to PR head in the next step.
-        if: steps.baseline-check.outputs.available == 'true' && steps.cache-base.outputs.cache-hit != 'true'
+        # Always run the base bench on the same runner that will run the
+        # head bench, so the two measurements share heap allocator state,
+        # neighbour load, and CPU model. The previous design cached the
+        # base bench across PRs (key `bench-base-v3-<crate>-<sha>`) and
+        # restored it from a *different* runner on cache hits — which
+        # turned every cache-hit PR into a cross-machine comparison
+        # against ±20-50 % runner-throughput drift. That dominated the
+        # bench gate's false-positive rate; see issue #24 for the
+        # analysis. Pinning same-machine comparisons here costs one
+        # extra base-bench run per PR but makes every comparison
+        # apples-to-apples.
+        if: steps.baseline-check.outputs.available == 'true'
         run: |
           set -euo pipefail
           git checkout "${{ steps.base-sha.outputs.sha }}"
           cargo bench -p ${{ matrix.crate }} --bench performance -- \
             --save-baseline pr-base $CRITERION_CI_FLAGS 2>&1 | tee bench-base.txt
-
-      - name: Persist base-branch baseline cache
-        # Save the freshly-captured baseline so the next PR against the
-        # same base SHA can skip the run entirely. Only fires on
-        # cache-miss — on hit the existing entry is already current.
-        if: steps.baseline-check.outputs.available == 'true' && steps.cache-base.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          key: bench-base-v3-${{ matrix.crate }}-${{ steps.base-sha.outputs.sha }}
-          path: |
-            target/criterion
-            bench-base.txt
 
       - name: Compare PR head against baseline
         if: steps.baseline-check.outputs.available == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,9 +2,26 @@ name: bench
 
 on:
   pull_request:
+    # Trigger only on changes that can plausibly affect bench output.
+    # `grafo/**` / `goap-planner/**` would also fire on README, docs/,
+    # examples/, tests/, CLAUDE.md, and assets/ changes — none of which
+    # influence the compiled bench binary, but each one would burn a
+    # full bench run on every doc-touching PR.
     paths:
-      - 'grafo/**'
-      - 'goap-planner/**'
+      # Source code compiled into the bench binary, the bench file
+      # itself, and the per-crate manifest (dev-dep edits change what
+      # links into bench).
+      - 'grafo/src/**'
+      - 'grafo/benches/**'
+      - 'grafo/Cargo.toml'
+      - 'goap-planner/src/**'
+      - 'goap-planner/benches/**'
+      - 'goap-planner/Cargo.toml'
+      # Workspace-level files that affect dependency resolution and
+      # therefore the compiled bench binary across both crates.
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      # CI infra for the bench gate itself.
       - '.github/workflows/bench.yml'
       - '.github/scripts/detect-bench-regression.py'
 

--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -101,27 +101,30 @@ at the workspace root — both the baseline and PR-head bench runs resolve
 identical dependency versions instead of regenerating the lockfile when
 a PR adds dev-deps to one workspace member.
 
-### Base-branch baseline cache
+### Base-branch baseline (same-machine comparisons)
 
-The base-branch bench result is the same for every PR opened against the
-same `main` SHA, but a naive workflow re-runs it every time. The bench
-workflow caches that result keyed by `bench-base-v3-<crate>-<base-sha>`,
-storing `target/criterion/` (where criterion's `pr-base` baseline data
-lives) plus the raw `bench-base.txt` log. On cache hit the base-bench
-step is skipped entirely; on miss it runs as before and the result is
-saved for the next PR. The cache invalidates naturally whenever `main`
-moves — the SHA is part of the key — so a stale baseline can never
-silently shadow a base-branch change.
+Every PR runs the base-branch bench fresh on the same runner that runs
+the head bench. There is no cross-PR cache.
 
-The first PR after a `main` push pays the full base-bench cost; every
-subsequent PR against the same `main` SHA pays close to zero for that
-half of the workflow. Caches expire after 7 days of no access (GitHub's
-default), so a cold start happens roughly weekly on quiet branches.
+This used to be different: an earlier design ([item A in `docs/todo.md`](
+https://github.com/leopepe/automata-atelier/blob/d36b25e/docs/todo.md))
+cached the base-branch bench result by `bench-base-v3-<crate>-<base-sha>`
+and skipped the base run on cache hits. That design tripled to
+quadrupled the bench gate's false-positive rate, because every cache
+hit became a cross-machine comparison: base measured on runner X,
+head measured on runner Y. GitHub-hosted runners drift ±20-50 % in
+micro-bench throughput from heap allocator state, neighbour load,
+and CPU model — and that drift surfaced as regressions of 50-100 %
+on small benches. PR #5, #6, and #26 all needed the
+`bench:allow-regression` workaround label as a result; see issue
+#24 for the full analysis.
 
-The `v3` segment in the cache key is a profile version: bump it
-whenever the CI sampling settings or bench-case set changes so cached
-baselines captured under the old profile cannot mix with head runs
-under the new one.
+Pinning same-machine comparisons costs one extra base-bench run per
+PR (no cache-hit shortcut), but it makes every comparison
+apples-to-apples and the gate's verdicts trustable. Combined with
+the reduced criterion sampling (B) and CI bench-case subset (D),
+each crate's full base + head sequence runs in ~5-7 minutes; the two
+crates run in parallel via the matrix.
 
 ### CI sampling profile
 
@@ -170,9 +173,10 @@ only small inputs could land. Acceptable for a threshold-based gate;
 local profiling and the canonical bench artifacts under `docs/` are
 the right tools for size-curve analysis, not the CI gate.
 
-The cache key carries this profile too: bumping it (`bench-base-v2-…`
-→ `bench-base-v3-…` in this change) prevents a full-sweep baseline
-captured under the old profile from mixing with subset head runs.
+(The earlier cache-key bump from `bench-base-v2-…` to
+`bench-base-v3-…` is now historical — the cache itself was removed
+together with the cross-machine comparison problem; see the previous
+section.)
 
 ### Overriding the gate for an intentional trade-off
 

--- a/goap-planner/benches/performance.rs
+++ b/goap-planner/benches/performance.rs
@@ -281,10 +281,27 @@ fn bench_state_ops(c: &mut Criterion) {
     });
 
     // insert — single-fact mutation cost.
+    //
+    // Uses `iter_batched_ref` (not `iter_batched`) so the State is borrowed
+    // across iterations and its drop falls outside the timed window. The
+    // earlier `iter_batched` form moved the State into the closure each
+    // iteration, which dropped a 100-fact `FxHashSet` *inside* the timed
+    // window — `State::insert` is ~50 ns but observed time was ~1 µs, of
+    // which ~99 % was drop. See issue #24.
+    //
+    // Each call inserts a uniquely-named fact, so the state grows by one
+    // per batch iteration; FxHashSet inserts are O(1) regardless of size,
+    // so this still measures the per-insert cost. Drops happen at batch
+    // boundaries, amortised over the whole batch.
     group.bench_function("insert", |b| {
-        b.iter_batched(
-            || State::from_facts((0..100).map(|i| format!("fact_{i}"))),
-            |mut s| s.insert(black_box("new_fact")),
+        let template = State::from_facts((0..100).map(|i| format!("fact_{i}")));
+        let mut counter: u64 = 0;
+        b.iter_batched_ref(
+            || template.clone(),
+            |s| {
+                counter = counter.wrapping_add(1);
+                s.insert(black_box(format!("new_fact_{counter}")));
+            },
             criterion::BatchSize::SmallInput,
         )
     });
@@ -381,6 +398,14 @@ fn bench_goal_check(c: &mut Criterion) {
 /// practice and shows wall-clock scaling.
 fn bench_concurrent_plans(c: &mut Criterion) {
     let mut group = c.benchmark_group("concurrent_plans");
+
+    // Pre-warm the global Rayon thread pool. Without this, the first
+    // parallel bench in this group pays for thread-pool spin-up inside
+    // its timed window, and per-runner startup variance shows up as
+    // false positives on the regression gate. See issue #24.
+    (0..256u32)
+        .into_par_iter()
+        .for_each(|_| std::hint::spin_loop());
 
     // Use a non-trivial chain plan as the per-call workload.
     let (actions, initial, goal) = chain_plan(20);

--- a/grafo/benches/performance.rs
+++ b/grafo/benches/performance.rs
@@ -220,7 +220,7 @@ fn bench_construction(c: &mut Criterion) {
                 .iter()
                 .map(|&(a, b, w)| (labels[a].as_str(), labels[b].as_str(), w))
                 .collect();
-            b.iter(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
+            b.iter_with_large_drop(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
         });
 
         group.bench_with_input(BenchmarkId::new("sparse_dag_fan4", n), &n, |b, &n| {
@@ -245,7 +245,7 @@ fn bench_construction(c: &mut Criterion) {
                 .iter()
                 .map(|&(a, b, w)| (labels[a].as_str(), labels[b].as_str(), w))
                 .collect();
-            b.iter(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
+            b.iter_with_large_drop(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
         });
     }
 
@@ -485,7 +485,7 @@ fn bench_construction_parallel(c: &mut Criterion) {
             .collect();
 
         group.bench_with_input(BenchmarkId::new("sparse_dag_fan4", n), &n, |b, _| {
-            b.iter(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
+            b.iter_with_large_drop(|| Graph::new(black_box(&nodes), black_box(&edges)).unwrap())
         });
     }
 


### PR DESCRIPTION
Closes #24.

## Summary

Both fixes recommended in #24 — **(a)** pin same-machine bench comparisons (workflow change) and **(b)** redesign the drop- and warmup-dominated micro-benches (per-bench surgery). Composes into a single PR because the bench changes only make sense with the same-machine comparison in place.

## (a) Drop the cross-PR cache

`.github/workflows/bench.yml`: removed the `Restore base-branch baseline cache` + `Persist base-branch baseline cache` steps. The `Save base-branch baseline` step now always runs when a base bench is available, guaranteeing base and head measurements share the same runner.

The earlier design (cache key `bench-base-v3-<crate>-<base-sha>`) saved CI time by skipping the base run when a prior PR had already measured it for the same `main` SHA — but on cache hit it turned the comparison into "base on runner X vs head on runner Y", with ±20-50 % cross-runner drift surfacing as 50-100 % regressions on small benches. PR #5, #6, and #26 all hit this and merged with the `bench:allow-regression` label.

Tradeoff: one extra base-bench run per PR (no cache-hit shortcut). With reduced sampling (B) and bench subset (D) already in place, base + head is ~5-7 min per crate, two crates in parallel matrix.

## (b) Bench-level fixes on the chronically-flaky cases

| Bench | Old | New | Why |
|---|---|---|---|
| `goap-planner ops/state/insert` | `iter_batched` (closure consumes State, drops in timed window) | `iter_batched_ref` with monotonic counter for unique facts | `State::insert` is ~50 ns; observed ~1 µs was 99 % drop of the 100-fact `FxHashSet` |
| `goap-planner concurrent_plans/*` | First parallel bench pays for Rayon pool spin-up inside its timed window | Small `into_par_iter` pre-warm before any timed bench | Per-runner thread-pool startup variance was the second-largest noise source |
| `grafo construction/*` (chain, sparse_dag_fan4, parallel_sort) | `iter(\|\| Graph::new(...))` (drop in timed window) | `iter_with_large_drop(\|\| Graph::new(...))` | At 100k–500k node sizes, dropping the CSR vectors / node-id map dominates the measurement; `iter_with_large_drop` is criterion's purpose-built tool for this |

The bench surgery is conservative — same fixtures, same workloads, same metric semantics. The only difference is that drops and pool-warmup don't pollute the timed window. Reported numbers will go down (improvements, not regressions) so the gate doesn't fire on the change itself.

## Docs

`docs/performance-tests.md`: replaced the `Base-branch baseline cache` section with `Base-branch baseline (same-machine comparisons)` documenting why the cache was removed and the trade-off. The v2→v3 cache-key bump note is marked as historical.

## Conventional commit

Type: [x] `fix`. Scope: `ci` (touches `bench.yml` and bench files; no source code changes).

## Breaking changes

None — public APIs, command surfaces, and bench identifiers are unchanged. The reported numbers for the redesigned benches will shift (drop excluded → smaller numbers), but the bench gate triggers only on regressions and improvements are silent.

## Test plan

- [x] `cargo fmt --all` (clean via `--check`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual: `cargo build --benches` clean; the redesigned benches use criterion APIs that already exist in the locked criterion 0.5.x.
- [ ] **CI bench will be the real test** — the goal is for this PR's own bench check to come back green without needing the workaround label, demonstrating the fragility is gone. If false positives still happen at the same rate, the fix is incomplete and #24 stays open.

## Linked issues

Closes #24.

If this lands clean, **#23** (parallelize bench-base/head into separate matrix jobs, currently `status:blocked`) becomes irrelevant — the recommended fix here directly conflicts with that issue's premise. Worth either closing #23 as superseded or leaving it open as "low-priority cache-miss optimisation" depending on how you'd rather frame it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)