### PR TITLE
docs(adrs): add ADR guideline, MADR template, index, and adr skill

### DIFF
--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: adr
+description: >
+  Draft, propose, or update an Architecture Decision Record (ADR) for this
+  workspace. Triggers AUTOMATICALLY whenever the conversation is taking — or
+  has just taken — a decision that touches: architecture or layering between
+  crates (grafo, goap-planner, uncharles); core components (graph kernel,
+  planner, executor) being introduced, swapped, or significantly reshaped;
+  performance constraints (algorithm choice, data structure, allocation
+  strategy, sync vs async vs rayon, benchmark gate thresholds); security
+  posture (trust boundaries, auth, secret handling, sandboxing, supply chain);
+  user interface (CLI verbs, resources, flags, output formats, exit codes
+  beyond what coding-guidelines.md already covers); integration interface
+  (YAML/config schema, HTTP/gRPC contract, plugin or extension API); or
+  operability (logging, metrics, signal handling, replan triggers, dry-run
+  semantics) — anything that changes how users or developers operate the
+  system; or guidelines / process (adding, removing, or materially changing a
+  workspace rule under docs/ or any CLAUDE.md, the PR / issue templates, the
+  label scheme, the commit-convention policy, the lint / format toolchain, or
+  CI gate semantics — but NOT typo fixes or pure rewording of an existing
+  rule). Also use when the user explicitly says "ADR", "decision record",
+  "let's record this decision", "supersede ADR NNNN", or invokes /adr.
+  Do NOT invoke for routine bug fixes, internal refactors that do not change a
+  public boundary, doc edits that only clarify or fix typos in an existing
+  rule, dependency bumps without semantic change, or test additions.
+tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# adr — draft or update an Architecture Decision Record
+
+This skill captures architectural decisions in the canonical format used by
+this workspace (MADR 4.0.0). It is bound by — and must follow —
+[`docs/adrs.md`](../../../docs/adrs.md). Read that file first; this skill is a
+runner, not a substitute for the guideline.
+
+## When to invoke
+
+Invoke the skill when, in the current conversation, a decision is being or has
+been taken in any of these categories:
+
+- **Architecture / layering** — boundaries between `grafo`, `goap-planner`,
+  `uncharles`; introduction or removal of a crate; foundational pattern choice.
+- **Core components** — which library underpins a kernel responsibility (graph
+  search, planner, executor, parser).
+- **Performance** — algorithm, data structure, allocation strategy, concurrency
+  model (sync / `async` / `rayon`), benchmark gate thresholds.
+- **Security** — trust boundaries, auth, secret handling, sandbox of executed
+  actions, supply-chain controls.
+- **User interface** — CLI verb/resource grammar changes, output format
+  additions, `--help` semantics, exit-code policy beyond
+  `coding-guidelines.md`'s baseline.
+- **Integration interface** — YAML/config schema, HTTP/gRPC contract, plugin
+  or extension API.
+- **Operability** — logging, metrics, signal handling, replan triggers, dry-run
+  semantics.
+- **Guidelines and process** — adding, removing, or materially changing a
+  workspace rule. Includes `docs/coding-guidelines.md`,
+  `docs/performance-tests.md`, `docs/issues.md`, `docs/adrs.md`, any
+  `CLAUDE.md`, the PR / issue templates, the label scheme, branch-protection
+  rules, the commit-convention policy, the lint or format toolchain, and the
+  CI gate semantics.
+
+Also invoke when the user explicitly asks for an ADR (`/adr`, "let's write an
+ADR", "record this decision", "supersede NNNN").
+
+**Do not invoke** for: bug fixes restoring documented behaviour, internal
+refactors that do not cross a public boundary, typo fixes or rewording in an
+existing guideline that does not change the underlying rule, doc-only
+formatting, test additions, dependency bumps without semantic change.
+
+## Procedure
+
+### Step 1 — Confirm an ADR is warranted
+
+When triggered automatically, first state out loud (one or two sentences) why
+you think the current discussion qualifies and which category it falls into.
+Then ask the user whether to proceed with drafting an ADR. Examples:
+
+- "This looks like a **performance** decision (switching from `Vec` to
+  `SmallVec` in the planner's hot loop). Per `docs/adrs.md`, that's
+  ADR-worthy. Want me to draft one?"
+- "We're taking an **integration interface** decision (adding a new YAML key
+  `sensors[].timeout_ms`). That meets the ADR bar — should I draft it?"
+
+Do not draft silently. The user must opt in. If they decline, drop the topic;
+do not nag.
+
+If the user invokes the skill explicitly (`/adr` or "write an ADR"), skip the
+warrant check and go straight to Step 2.
+
+### Step 2 — Gather inputs
+
+Ask the user for these, all at once:
+
+1. **Title** — short, declarative (will become the heading and the kebab
+   filename). Example: "Forbid async in goap-planner".
+2. **Driving issue** — GitHub issue number(s) if one exists. Optional but
+   strongly preferred; use `Refs #N`.
+3. **Decision drivers** — the forces that mattered (1–4 bullets).
+4. **Considered options** — at least two; one may be "do nothing".
+5. **Chosen option** plus a one-paragraph justification.
+6. **Consequences** — both positive and negative bullets.
+7. **Confirmation** — how compliance is verified (test, bench guard, lint,
+   review checklist). Optional but encouraged.
+8. **Decision-makers** — the people / roles. Optional.
+9. **Supersedes** — ADR number(s) being replaced, if any.
+
+If the conversation already contains enough material to fill these in, draft
+the ADR and ask the user to confirm or correct, rather than re-asking.
+
+### Step 3 — Determine the next free ADR number
+
+Run from the workspace root:
+
+```sh
+ls docs/adrs/ | grep -E '^[0-9]{4}-' | sort | tail -1
+```
+
+Increment the leading number by one and zero-pad to four digits. If
+`docs/adrs/` has only `0000-template.md` and `README.md`, the next number is
+`0001`.
+
+### Step 4 — Create the ADR file
+
+Copy `docs/adrs/0000-template.md` to `docs/adrs/NNNN-<kebab-title>.md` and
+fill it in. Required fields:
+
+- Front-matter: `status: proposed`, `date: <today, YYYY-MM-DD>`,
+  `decision-makers`, optional `consulted` / `informed`, optional
+  `supersedes: NNNN`.
+- Body: `Context and Problem Statement` (linking the issue with `Refs #N`),
+  `Decision Drivers`, `Considered Options`, `Decision Outcome`, `Consequences`.
+- Optional: `Confirmation`, `Pros and Cons of the Options`, `More Information`.
+
+Keep it short. Aim for 30–80 lines of markdown.
+
+### Step 5 — Update the index
+
+Add a row to `docs/adrs/README.md` under the **Records** table. Replace the
+placeholder row if this is the first ADR. The row format is:
+
+```
+| 0001 | [<Title>](./0001-<kebab-title>.md) | proposed | YYYY-MM-DD |
+```
+
+Keep the table sorted by ADR number ascending.
+
+### Step 6 — If superseding an existing ADR
+
+If the new ADR replaces an older one, edit the older ADR in the same change:
+
+- Set `status: superseded` in its front-matter.
+- Add `superseded-by: NNNN` (the new ADR's number).
+- Update its row in `docs/adrs/README.md` to reflect the new status.
+
+### Step 7 — Hand back to the user
+
+Report:
+
+1. The new ADR's path and number.
+2. The index entry that was added or updated.
+3. A reminder that the commit should follow the workspace Conventional
+   Commits convention with the `docs(adrs):` scope, e.g.
+   `docs(adrs): add ADR NNNN for <short title>`.
+4. A reminder that `status: proposed` must be flipped to `accepted` only after
+   PR ratification.
+
+Do not commit, push, or open a PR yourself unless the user explicitly asks.
+
+## Reference
+
+- Guideline: [`docs/adrs.md`](../../../docs/adrs.md)
+- Index: [`docs/adrs/README.md`](../../../docs/adrs/README.md)
+- Template: [`docs/adrs/0000-template.md`](../../../docs/adrs/0000-template.md)
+- Format: [MADR 4.0.0](https://adr.github.io/madr/)
+- Commit / PR conventions:
+  [`docs/coding-guidelines.md`](../../../docs/coding-guidelines.md)
+  under "Commits and pull requests".

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,13 @@ perf.data*
 *~
 
 # Claude Code workspace state — local-only settings, transcripts, memory.
-.claude/
+# Ignore the contents of .claude/ rather than the directory itself, so the
+# re-include below can take effect (git doesn't recurse into an ignored
+# directory).
+.claude/*
+# Exception: project-scoped skills are shared workspace tooling and do get
+# checked in. Anything else under .claude/ stays local.
+!.claude/skills/
 
 # --- OS junk --------------------------------------------------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Specifically:
 - **Before writing or modifying any code**, read [`docs/coding-guidelines.md`](./docs/coding-guidelines.md). It is the source of truth for tests, lint and format gates, documentation duties, commit and PR conventions, and the "when in doubt" defaults.
 - **Before touching a core library's hot path** (currently `grafo` or `goap-planner`), read [`docs/performance-tests.md`](./docs/performance-tests.md).
 - **Before opening or updating a GitHub issue**, read [`docs/issues.md`](./docs/issues.md).
+- **Before taking a decision that touches architecture, core components, performance, security, or a user/integration interface**, read [`docs/adrs.md`](./docs/adrs.md). It defines when an Architecture Decision Record (ADR) is required, the MADR format we use, and the workflow for ratifying one.
 
 When new workspace-wide documentation is added under `docs/`, the index in `docs/CLAUDE.md` is updated to list it; check there first rather than guessing what exists.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -20,6 +20,11 @@ the required benchmark surface, the workflow, and what CI enforces.
 If you are about to open or update a GitHub issue, read
 [`issues.md`](./issues.md) for the templates, labels, and lifecycle.
 
+If a decision is being taken that touches architecture, core components,
+performance, security, or a user/integration interface, read
+[`adrs.md`](./adrs.md) — it defines when an Architecture Decision Record is
+required, the MADR format used, and the workflow for ratifying one.
+
 ## What lives in this directory
 
 | File | Purpose |
@@ -27,6 +32,8 @@ If you are about to open or update a GitHub issue, read
 | [`coding-guidelines.md`](./coding-guidelines.md) | Workspace coding rules: tests, lint/format, docs, commits, PRs. Read before any code change. |
 | [`performance-tests.md`](./performance-tests.md) | Benchmark suite requirements for core libraries; flamegraphs, perf comparisons, CI. |
 | [`issues.md`](./issues.md) | How to file and triage GitHub issues: templates, labels, linking to PRs. |
+| [`adrs.md`](./adrs.md) | Architecture Decision Records: when to write one, MADR format, lifecycle. |
+| [`adrs/`](./adrs/) | The ADR records themselves, plus the template and index. |
 | `CLAUDE.md` | This index. |
 
 When new workspace-wide documentation is added, list it here so it is

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -1,0 +1,177 @@
+# Architecture Decision Records (ADRs)
+
+How architectural decisions are captured in this workspace. ADRs are short,
+durable records of *significant* technical decisions: what was chosen, what was
+considered, and why. They sit next to the code they describe and travel with
+the repository.
+
+ADRs are complementary to GitHub issues:
+
+- **Issues** are where decisions get *discussed* and tracked through review
+  (`type:design`, `type:feature`, `type:bug`). See [`issues.md`](./issues.md).
+- **ADRs** are where decisions get *recorded* once made, in a stable, citable
+  form. An ADR's `Refs` link points back at the issue(s) that drove it.
+
+If a discussion never reaches a meaningful decision, it stays an issue. If a
+decision is taken that meets the bar in [When to write an ADR](#when-to-write-an-adr),
+it gets an ADR.
+
+## Where ADRs live
+
+```
+docs/
+  adrs.md                       # this guideline
+  adrs/
+    README.md                   # index — every ADR listed with status + date
+    0000-template.md            # the MADR template; copy this to start a new ADR
+    0001-<kebab-title>.md       # individual records, sequentially numbered
+    0002-<kebab-title>.md
+    ...
+```
+
+- **Filename**: `NNNN-kebab-case-title.md`. Four-digit zero-padded sequential
+  number, hyphen, then the title in lowercase kebab case.
+- **Numbering**: monotonic across the workspace. Pick the next free number;
+  never re-use a number, even after a record is superseded.
+- **Title** in the filename mirrors the `# {title}` heading at the top of the
+  file. Keep it short and imperative-ish (`use-grafo-as-graph-kernel`,
+  `forbid-async-in-goap-planner`).
+
+## Format: MADR 4.0.0
+
+We use [MADR 4.0.0](https://adr.github.io/madr/) (Markdown Any Decision Records)
+short form. It is the most actively maintained ADR template, structured enough
+to capture trade-offs (`Decision Drivers`, `Considered Options`, `Consequences`)
+without ceremony.
+
+The canonical template lives at [`adrs/0000-template.md`](./adrs/0000-template.md);
+copy it when starting a new ADR. Required sections:
+
+- **YAML front-matter** — `status`, `date`, `decision-makers`, optional
+  `consulted` and `informed`, optional `supersedes` / `superseded-by`.
+- **Title** — `# <short, declarative title>` matching the filename.
+- **Context and Problem Statement** — two or three sentences. Link the
+  driving issue with `Refs #N`.
+- **Decision Drivers** — the forces / constraints that mattered.
+- **Considered Options** — at least two; one of them may be "do nothing".
+- **Decision Outcome** — chosen option plus a one-paragraph justification.
+- **Consequences** — bulleted, both `Good, because …` and `Bad, because …`.
+
+Optional but encouraged:
+
+- **Confirmation** — how compliance is verified (a test, a benchmark guard,
+  a lint, a code review checklist).
+- **Pros and Cons of the Options** — flesh out the trade-off when more than
+  two options were close.
+- **More Information** — links to issues, PRs, prior art, follow-ups.
+
+Keep ADRs short. A typical record is 30–80 lines of markdown; 200+ is a smell
+that the decision is actually several decisions and should be split.
+
+### Status lifecycle
+
+The `status` field in the front-matter takes one of:
+
+- `proposed` — drafted, not yet ratified. Discussion still open.
+- `accepted` — ratified. The current behaviour of the workspace.
+- `deprecated` — discouraged but not yet removed. The record stays for history.
+- `superseded` — replaced by a newer ADR. The front-matter must include
+  `superseded-by: NNNN`, and the superseding ADR must link back via
+  `supersedes: NNNN`.
+
+Once an ADR is `accepted`, do not edit its decision retroactively. If the
+decision changes, write a new ADR that supersedes it. Typo fixes and link
+updates are fine; semantic edits are not.
+
+## Indexing
+
+[`adrs/README.md`](./adrs/README.md) is the canonical index. Every ADR is
+listed there in a table:
+
+| #    | Title                              | Status     | Date       |
+| ---- | ---------------------------------- | ---------- | ---------- |
+| 0001 | [Use grafo as graph kernel](./adrs/0001-use-grafo-as-graph-kernel.md) | accepted   | 2026-05-02 |
+| 0002 | [Forbid async in goap-planner](./adrs/0002-forbid-async-in-goap-planner.md) | accepted   | 2026-05-02 |
+
+When you add or change an ADR's status, update the index in the same commit.
+The index is the source of truth for "what decisions exist?"; the filesystem
+listing is a fallback.
+
+## When to write an ADR
+
+Write an ADR whenever a decision lands in any of these categories. The bar is
+"would a future contributor be confused, surprised, or tempted to undo this if
+they didn't know why we did it?". If yes, ADR.
+
+**You must write an ADR for:**
+
+- **Architecture**: layering, ownership boundaries, the contract between the
+  crates (`grafo` ↔ `goap-planner` ↔ `uncharles`), introduction or removal of
+  a crate, choice of foundational pattern (event loop vs. actor vs. pipeline).
+- **Core components**: which library underpins a kernel responsibility (graph
+  search, planner, executor, parser). Swapping or significantly reshaping such
+  a component is an ADR.
+- **Performance**: any decision that constrains future work for performance
+  reasons — choice of algorithm, data structure, allocation strategy,
+  concurrency model (sync vs. `async` vs. `rayon`), benchmark gate thresholds.
+- **Security**: trust boundaries, authentication/authorisation choices,
+  secret-handling, sandboxing of executed actions, supply-chain controls
+  (signed deps, vendoring policy).
+- **User interface**: CLI verb/resource grammar changes that aren't already
+  covered by [CLI conventions](./coding-guidelines.md#cli-conventions-posix--kubectl),
+  output format additions, `--help` semantics, exit-code policy.
+- **Integration interface**: YAML/config schema, HTTP/gRPC contract, plugin or
+  extension API — anything an external consumer codes against.
+- **Operability**: anything that changes how operators run, observe, debug,
+  or recover the system in production (logging policy, metrics surface, signal
+  handling, replan triggers, dry-run semantics).
+- **Guidelines and process**: adding a new workspace guideline, removing one,
+  or materially changing one. Includes `docs/coding-guidelines.md`,
+  `docs/performance-tests.md`, `docs/issues.md`, `docs/adrs.md` itself, any
+  `CLAUDE.md`, the PR / issue templates, the label scheme, branch-protection
+  rules, the commit-convention policy, the lint or format toolchain, and the
+  CI gate semantics. The ADR captures *why* the workspace works this way so a
+  future contributor sees the rationale and not just the rule.
+
+**You may skip an ADR for:**
+
+- Purely internal refactors that do not change a public boundary.
+- Bug fixes that restore documented behaviour.
+- Adding a test, a benchmark, a docstring, or formatting changes.
+- Dependency bumps that don't change semantics.
+- Trivial new features that fit cleanly into an existing ADR's scope (note them
+  in that ADR's `More Information` section instead of writing a new one).
+- Tightening, clarifying, or fixing typos in an existing guideline without
+  changing the underlying rule. New rules and rule reversals always need an
+  ADR; rewording the same rule does not.
+
+When in doubt, lean toward writing one. ADRs are cheap; rediscovering "why is
+it like this?" six months later is not.
+
+## Workflow
+
+1. **Open or reference an issue** under the appropriate template (usually
+   `type:design`). Discuss until a decision is reachable.
+2. **Copy `docs/adrs/0000-template.md`** to `docs/adrs/NNNN-<title>.md` with
+   the next free number. Set `status: proposed`.
+3. **Fill in the record**, link the issue with `Refs #N`, and open a PR. The
+   PR's purpose is to ratify the ADR; reviewers comment on the markdown.
+4. **Update [`adrs/README.md`](./adrs/README.md)** in the same commit so the
+   index reflects the new entry.
+5. **Flip to `status: accepted`** once the PR is approved. Squash-merge.
+6. **If a later ADR overrides this one**, set the front-matter to
+   `status: superseded`, add `superseded-by: NNNN`, and update the index. Do
+   not delete the file or rewrite its decision.
+
+## Commits and PRs
+
+ADR commits follow the workspace's [Conventional Commits](./coding-guidelines.md#commits-and-pull-requests)
+rules. Use the `docs` type with the `adrs` scope:
+
+- `docs(adrs): add ADR 0007 for executor sandboxing`
+- `docs(adrs): supersede 0003 with 0011 (new bench gate policy)`
+- `docs(adrs): mark 0004 deprecated`
+
+PR titles follow the same convention. The PR body uses the workspace template
+and links the driving issue with `Closes #N` (if the ADR fully resolves the
+discussion) or `Refs #N`.

--- a/docs/adrs/0000-template.md
+++ b/docs/adrs/0000-template.md
@@ -1,0 +1,77 @@
+---
+status: proposed
+date: YYYY-MM-DD
+decision-makers: []
+consulted: []
+informed: []
+# supersedes: NNNN          # set if this ADR replaces a previous one
+# superseded-by: NNNN       # set when a later ADR replaces this one
+---
+
+# {short, declarative title — matches the filename}
+
+## Context and Problem Statement
+
+{Two or three sentences. What is the situation, and what decision is forced?
+Link the driving issue: `Refs #N`. If a perf bench, security review, or user
+report triggered this, mention it.}
+
+## Decision Drivers
+
+* {force / constraint 1 — why it matters}
+* {force / constraint 2}
+* {force / constraint 3}
+
+## Considered Options
+
+* {option 1}
+* {option 2}
+* {option 3 — may be "do nothing"}
+
+## Decision Outcome
+
+Chosen option: **"{option N}"**, because {one-paragraph justification —
+which drivers it satisfies and which trade-offs were accepted}.
+
+### Consequences
+
+* Good, because {positive consequence}.
+* Good, because {positive consequence}.
+* Bad, because {negative consequence — what we now have to live with}.
+* Bad, because {negative consequence}.
+
+### Confirmation
+
+{How is compliance with this decision verified? A test, a benchmark guard,
+a clippy lint, a CI workflow, a code-review checklist item? If nothing
+automated exists, say so explicitly. Optional but encouraged.}
+
+## Pros and Cons of the Options
+
+### {option 1}
+
+{One-line description or pointer.}
+
+* Good, because {…}.
+* Neutral, because {…}.
+* Bad, because {…}.
+
+### {option 2}
+
+{One-line description or pointer.}
+
+* Good, because {…}.
+* Bad, because {…}.
+
+### {option 3}
+
+{One-line description or pointer.}
+
+* Good, because {…}.
+* Bad, because {…}.
+
+## More Information
+
+{Links to related ADRs, issues, PRs, prior art, follow-up tasks. If this ADR
+should be revisited under a specific condition (a benchmark threshold, a
+release milestone, a new dependency), record that trigger here.}

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,23 @@
+# ADR index
+
+Every architectural decision record (ADR) in this workspace, listed by number.
+This file is the canonical index — keep it in sync with the filesystem in the
+same commit that adds, supersedes, or deprecates an ADR.
+
+For the format, lifecycle, and "when to write one" rules see
+[`../adrs.md`](../adrs.md). To start a new ADR, copy
+[`0000-template.md`](./0000-template.md) to `NNNN-<kebab-title>.md` using the
+next free number.
+
+## Records
+
+| #    | Title | Status | Date |
+| ---- | ----- | ------ | ---- |
+| —    | _No ADRs yet. The first decision recorded here will be `0001`._ | — | — |
+
+## Status legend
+
+- `proposed` — drafted, not yet ratified.
+- `accepted` — ratified; current behaviour of the workspace.
+- `deprecated` — discouraged but not yet removed.
+- `superseded` — replaced by a newer ADR (linked via `superseded-by`).

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -8,7 +8,7 @@ Open an issue when:
 
 - A behaviour is broken or has regressed → **bug report**.
 - A new user-visible capability is wanted → **feature request**.
-- A design discussion needs durable capture (architectural choices, API shape, "we should reconsider X") → **design proposal**.
+- A design discussion needs durable capture (architectural choices, API shape, "we should reconsider X") → **design proposal**. Once such a discussion reaches a decision that meets the bar in [`adrs.md`](./adrs.md), record it as an ADR and reference the issue with `Refs #N`.
 
 If a thing is already a tiny PR you're about to open and the discussion fits in the PR description, skip the issue. Issues exist for things that need to be discussed, prioritised, or carried across multiple PRs.
 


### PR DESCRIPTION
Introduces Architecture Decision Records as a first-class artifact for the workspace:

- docs/adrs.md — guideline: directory layout, MADR 4.0.0 short-form format, status lifecycle (proposed → accepted → deprecated/superseded), indexing rules, and the bar for when an ADR is required (architecture, core components, performance, security, user / integration interface, operability, and guidelines / process).
- docs/adrs/README.md — canonical index of records.
- docs/adrs/0000-template.md — MADR 4.0.0 short-form template.
- .claude/skills/adr/SKILL.md — project-scoped Claude skill that auto-triggers on ADR-worthy discussions and walks through warrant check, input gathering, next-number lookup, file creation, and index update.
- .gitignore — narrow the .claude/ ignore so .claude/skills/ can be checked in while sessions, transcripts, and memory stay local.
- CLAUDE.md, docs/CLAUDE.md, docs/issues.md — link the new guideline from the existing index files and from the type:design issue note.

## Summary

<!-- 1–3 bullets: what this PR does and why. Focus on the why; the diff shows the what. -->

-

## Conventional commit

<!-- The squash/merge commit message must follow Conventional Commits 1.0.0. The PR title should already match. -->

Type (check one):

- [ ] `feat` — new user-visible capability
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting, whitespace, no behaviour change
- [ ] `refactor` — internal change, no behaviour or interface change
- [ ] `perf` — performance improvement
- [ ] `test` — adding or fixing tests
- [ ] `build` — build system, dependencies, tooling
- [ ] `ci` — CI configuration
- [ ] `chore` — other non-source/non-test changes
- [ ] `revert` — reverts a prior commit

Scope (crate or area, e.g. `grafo`, `goap-planner`, `uncharles`, `ci`, `docs`):

`<scope>`

## Breaking changes

<!-- If breaking, the title must use `!` (e.g. `feat(grafo)!: ...`) AND include a `BREAKING CHANGE:` footer in the merge commit. Otherwise write "None". -->

None.

## Test plan

- [ ] `cargo fmt --all`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Manual verification (describe):

## Linked issues

<!-- e.g. Closes #123, Refs #456 -->
