### PR TITLE
feat(uncharles): add tofu_drift_watch.yaml post-apply convergence watcher

### DIFF
--- a/docs/adrs/0002-uncharles-as-post-apply-iac-convergence-watcher.md
+++ b/docs/adrs/0002-uncharles-as-post-apply-iac-convergence-watcher.md
@@ -1,0 +1,201 @@
+---
+status: accepted
+date: 2026-05-03
+decision-makers: ["@leopepe"]
+consulted: []
+informed: []
+---
+
+# Use uncharles as a post-apply IaC convergence watcher, not a CI replacement
+
+## Context and Problem Statement
+
+`uncharles` is shaped like the loop "did our last push to `main` actually
+converge the world, and is the world still converged now?" — sense, plan,
+act, replan on divergence. Empirical sampling of two weeks of failed runs in
+the `Infrastructure Pipeline` workflow at `hyground-ai/hyground` showed that
+this loop has a clear home: **between** CI pushes, scoped to one
+state key, asking `tofu plan -refresh-only` whether the deployed world still
+matches `main`. That is signal CI does not produce. The decision to make is
+which of three plausible roles `uncharles` plays in the IaC lifecycle, and
+how its config schema is shaped to support it. Refs #25.
+
+## Decision Drivers
+
+* **Complementarity over replacement.** CI already runs `plan` and `apply`
+  reliably. Re-implementing that loop inside `uncharles` adds risk without
+  producing a new signal, and forks a working code path.
+* **Blast radius.** A watcher reads state. A planner-applier writes state.
+  These have very different security postures (readonly vs. apply-capable
+  credentials, lock acquisition behaviour, recovery semantics on partial
+  failure). The first version must commit to one posture so reviewers can
+  reason about it.
+* **Coverage of real failure modes.** Of seven empirical failure categories
+  observed in the upstream workflow (lock-file vs. version-constraint drift,
+  state-schema drift, self-induced rug-pull, stale state lease, concurrent
+  runs across state keys, project-specific pre-fetch, cross-run drift), the
+  existing `release_watch.yaml` vocabulary covers roughly half. The chosen
+  role must make the remaining gaps explicit follow-up work, not silently
+  paper over them.
+* **Minimal surface to start.** A config the planner can statically analyse
+  with `uncharles inspect` and that exercises the runtime as it stands today
+  (no new YAML schema, no new exit-code semantics) lets us land the pattern
+  before any runtime change is required. Runtime gaps then have a concrete
+  example to point at when they're proposed individually.
+
+## Considered Options
+
+* **Option A — Replace the workflow.** Run `uncharles` in place of the CI
+  workflow's `plan` / `apply` jobs.
+* **Option B — Mirror the workflow as an `uncharles` config.** One config (or
+  one per cloud × tier) that runs `plan` → `apply` → `validate` outside CI.
+* **Option C — Post-apply convergence watcher.** `uncharles` runs *between*
+  pushes, scoped to one state key, asking "does `tofu plan -refresh-only`
+  still report no changes?" The watcher reads state with readonly credentials
+  and never applies.
+
+## Decision Outcome
+
+Chosen option: **"Option C — post-apply convergence watcher"**. It produces a
+signal CI does not produce (cross-run drift, silent state-schema decay,
+artifacts referenced by `tofu plan` going stale), it composes with the
+existing CI pipeline rather than competing with it, and its readonly-creds
+posture is small enough to reason about in a single review.
+
+The example config landed alongside this ADR
+([`uncharles/configs/tofu_drift_watch.yaml`](../../uncharles/configs/tofu_drift_watch.yaml))
+encodes the minimum viable shape: senses `push_completed`,
+`lock_file_in_sync`, `prefetch_done`, and the three-valued plan result
+(`plan_clean` / `plan_has_changes` / `plan_errored`); acts via `tofu_init`,
+`prefetch_artifacts`, `tofu_plan_refresh`, and three `archive_*` actions
+that surface the result and exit. The watcher does **not** apply, does
+**not** auto-remediate, and does **not** break state locks — those are
+explicit follow-ups gated on apply-capable credentials.
+
+### Consequences
+
+* Good, because the watcher is a strict superset of what CI produces: every
+  signal it emits is one CI structurally cannot produce between pushes.
+* Good, because the readonly-credentials posture is auditable in one line of
+  config (the cloud provider block bound to `*_READONLY_ROLE_ARN`-equivalents)
+  and cannot drift to apply-capable without a deliberate config change.
+* Good, because the example config is statically analysable today —
+  `uncharles inspect` finds orphan actions, unreachable goal facts, and
+  dead-end states without running anything.
+* Good, because runtime gaps surfaced by the empirical failure modes (per
+  state-key in-flight markers, three-valued plan exit codes as first-class
+  facts, stale-lock recovery, partial-apply detection, evidence archiving on
+  the failure path, lint preflight) become individually reviewable
+  follow-ups against a working baseline rather than entangled with the
+  "should we do this at all?" decision.
+* Bad, because the three-valued plan exit code is encoded today via a
+  wrapper script that writes `.uncharles/state/last_plan_exit` plus three
+  sensors that decode it. That is shell-in-config, not first-class facts —
+  acceptable as the bootstrap, ugly as the long-term shape. Tracked as a
+  follow-up gap (overlaps with issue #18 on value-carrying facts).
+* Bad, because drift surfaced by the watcher is human-triaged via
+  `archive_drift` / `archive_error` rather than auto-remediated. That is
+  deliberate (auto-remediation against possibly half-applied state is the
+  rug-pull failure mode) but it means the watcher does not by itself close
+  the loop on detected drift.
+* Bad, because the runtime today treats action exit codes as binary and
+  cannot natively model "plan succeeded but reports changes". Every config
+  using this pattern duplicates the wrapper-script trick until the runtime
+  gap lands.
+
+### Confirmation
+
+Compliance is verified by three lightweight gates:
+
+1. **Static analysis** — `cargo run -p uncharles -- inspect --config
+   uncharles/configs/tofu_drift_watch.yaml` exits `0` (no orphan actions,
+   no unreachable goal facts, no dead-end states off the goal path). This
+   runs as part of the workspace's standard `cargo test` because the config
+   ships in the crate's `configs/` directory and the inspect path is
+   exercised by the unit tests in `uncharles/src/inspect.rs`.
+2. **Schema parse** — the config deserialises under
+   `serde_yaml::from_str::<Config>` with `deny_unknown_fields`. The runtime's
+   own parse tests in `uncharles/src/config.rs` enforce the schema; adding a
+   typo'd field to the example would fail `cargo test -p uncharles`.
+3. **Code review checklist** — when adding new watcher configs, reviewers
+   confirm: (a) no action invokes `tofu apply`, (b) all `tofu` commands use
+   `-lockfile=readonly` or `-refresh-only`, (c) `archive_*` actions are pure
+   evidence-collection — they never mutate cloud or state.
+
+## Pros and Cons of the Options
+
+### Option A — replace the workflow
+
+* Good, because it removes a duplicated abstraction (CI + watcher both knowing
+  about plan/apply) at the cost of running `apply` from `uncharles`.
+* Bad, because it duplicates working code (the workflow already orchestrates
+  plan/apply across 12 concurrency groups) and replaces it with something
+  less battle-tested.
+* Bad, because the blast radius is enormous — a bug in `uncharles` could
+  apply against production state. CI's blast radius is bounded by GitHub's
+  job isolation; a long-lived watcher's is not.
+* Bad, because it produces no new signal: replacing CI with `uncharles`
+  doesn't tell us anything between pushes that CI didn't already tell us at
+  push time.
+
+### Option B — mirror the workflow as an `uncharles` config
+
+* Good, because it's a useful exercise for shaking out runtime gaps and
+  validates that `uncharles` can express the existing pipeline.
+* Bad, because the value-over-CI is small until `uncharles` does something
+  CI can't. We'd be writing a duplicate config that has to track every CI
+  change and adds a second source of truth.
+* Bad, because intra-cloud sequencing across 12 concurrency groups requires
+  per-state-key in-flight markers (gap 1 in #25) before this is even
+  expressible. We'd be paying that runtime cost up front for no new signal.
+
+### Option C — post-apply convergence watcher (chosen)
+
+* Good, because it produces a signal CI does not produce: cross-run drift,
+  state-schema decay, artifact freshness.
+* Good, because the readonly-creds posture caps blast radius at "wrong
+  evidence file written" — no path leads to mutating cloud state.
+* Good, because it's expressible *today* with the runtime as it stands:
+  binary action exit codes plus a small wrapper-script trick for the
+  three-valued plan result. Runtime improvements then have a working
+  baseline to compare against.
+* Neutral, because drift is human-triaged rather than auto-remediated. For
+  IaC, this is the conservative choice — auto-remediation against possibly
+  half-applied state is the documented "rug-pull" failure mode.
+* Bad, because some real failure modes (stale lease, lock-file drift,
+  partial-apply detection) are explicitly out-of-scope for the minimal
+  config. They are tracked as follow-ups, not silently glossed over.
+
+## More Information
+
+* **Driving issue**: #25 (this ADR is the captured form of its `accepted`
+  decision). The issue stays open for the six runtime-gap follow-ups it
+  enumerates; this ADR closes only the "which option do we adopt?"
+  sub-question.
+* **Example config**: [`uncharles/configs/tofu_drift_watch.yaml`](../../uncharles/configs/tofu_drift_watch.yaml).
+  Generic enough to drop into any OpenTofu repo; the project-specific bits
+  (prefetch script, archive script, watch-workflow name) are surfaced as
+  prereqs in the config's header comment.
+* **Follow-up gaps tracked separately** (each becomes its own
+  `type:design` or `type:feature` issue once scoped):
+  1. Per-state-key in-flight markers (replace the single `in_flight_sha`
+     idiom with `.uncharles/state/in_flight/<cloud>-<tier>-<env>`).
+  2. Three-valued plan exit code as first-class facts in the runtime
+     (overlaps with #18 on value-carrying facts).
+  3. `refresh_lock_file` action gated by an approval marker — recovery for
+     lock-file vs. version-constraint drift.
+  4. `apply_partial_detected` escape hatch — flips after any apply that
+     exited non-zero plus a follow-up `plan -refresh-only -detailed-exitcode
+     == 2`, gates further apply behind manual approval.
+  5. `archive_failure` action mirroring `archive_evidence` on the failure
+     path — captures stderr, state snapshot, SHA.
+  6. `lint_clean` precondition wrapping `tofu fmt -check && tofu validate` —
+     cheapest preflight, mirrors the upstream `lint-infrastructure` job.
+* **Trigger to revisit**: when any of the six follow-up gaps lands a runtime
+  change (especially gap 2 — three-valued exit codes as first-class facts),
+  this ADR's "Bad, because" point on shell-in-config can be retired and the
+  example config simplified. If a future role for `uncharles` (e.g., a
+  remediation agent that *does* hold apply-capable credentials) is
+  proposed, this ADR is the reference for the role this watcher chose
+  *not* to play, and the new ADR should be filed under a new number with
+  a `supersedes` link if the watcher and remediator cannot coexist.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -14,6 +14,7 @@ next free number.
 | #    | Title | Status | Date |
 | ---- | ----- | ------ | ---- |
 | 0001 | [Relax `main` ruleset for solo-contributor workflow](./0001-relax-main-ruleset-for-solo-contributor.md) | accepted | 2026-05-02 |
+| 0002 | [Use uncharles as a post-apply IaC convergence watcher, not a CI replacement](./0002-uncharles-as-post-apply-iac-convergence-watcher.md) | accepted | 2026-05-03 |
 
 ## Status legend
 

--- a/uncharles/README.md
+++ b/uncharles/README.md
@@ -123,6 +123,7 @@ Real configs covering different domains — read them as a tour of what the runt
 |---|---|
 | [`deploy.yaml`](configs/deploy.yaml) | Service deployment pipeline (test → build → push → deploy → smoke) |
 | [`release_watch.yaml`](configs/release_watch.yaml) | Long-lived release-tagging watcher |
+| [`tofu_drift_watch.yaml`](configs/tofu_drift_watch.yaml) | Post-apply OpenTofu/IaC convergence watcher (drift detection, readonly creds — see [ADR 0002](../docs/adrs/0002-uncharles-as-post-apply-iac-convergence-watcher.md)) |
 | [`merge_gate.yaml`](configs/merge_gate.yaml) | PR-merge gate with status-check sensors |
 | [`podcast.yaml`](configs/podcast.yaml) | Podcast-episode download pipeline (RSS → fetch → archive) |
 | [`repo_validate.yaml`](configs/repo_validate.yaml) | Repo-validation pipeline (fmt + clippy + test) |

--- a/uncharles/configs/tofu_drift_watch.yaml
+++ b/uncharles/configs/tofu_drift_watch.yaml
@@ -1,0 +1,178 @@
+# Post-apply convergence watcher for one OpenTofu state key. Verifies that
+# the deployed world (one cloud × one tier × one env, scoped by the state
+# backend the local working directory points at) stays converged with `main`
+# *between* CI pushes — drift detection, not plan/apply orchestration.
+#
+# Run from the IaC repo root (the directory `tofu init` would be run in)
+# with:
+#
+#   uncharles run --config tofu_drift_watch.yaml --execute --interval-ms 30000
+#
+# uncharles exits after one cycle: either at iteration 1 (NoPlan — push_completed
+# is false, CI is broken, do not probe) or after one of the `archive_*`
+# actions flips `idle` true. To probe continuously, wrap in:
+#
+#   while true; do uncharles run --config tofu_drift_watch.yaml --execute; sleep 600; done
+#
+# Five-to-ten-minute outer ticks are the right cadence — the steady state is
+# `tofu init -lockfile=readonly` plus one `gh run list` call per probe.
+#
+# Decision context: see `docs/adrs/0002-uncharles-as-post-apply-iac-convergence-watcher.md`.
+# This config is the minimum viable shape from option (c) of issue #25:
+# scoped to one state key, post-apply only, never plans/applies on its own.
+#
+# Sidecar state on disk (created lazily by the actions; clean up by deleting
+# the directory):
+#   .uncharles/state/last_plan_exit       — three-valued plan exit (0|1|2)
+#   .uncharles/state/prefetch_done        — present iff prefetch is fresh
+#   .uncharles/evidence/<utc_ts>/         — archived per-cycle evidence
+#
+# Prereqs in the target repo:
+#   - `tofu` on PATH; the working dir has a usable backend config
+#   - **readonly** cloud credentials in scope. The watcher must NEVER hold
+#     apply-capable creds — this is the security posture this config commits
+#     to. Stale-lock recovery and any apply-capable action are explicit
+#     follow-ups (see ADR 0002 "Follow-up gaps").
+#   - `gh` authenticated, `WATCH_WORKFLOW` exported (e.g. `infrastructure.yaml`)
+#   - `.uncharles/scripts/prefetch.sh` exists (project-specific: lambda zips,
+#     SOPS decrypt, anything `tofu plan` resolves at plan time). Idempotent;
+#     creates `.uncharles/state/prefetch_done` on success.
+#   - `.uncharles/scripts/tofu-plan-refresh.sh` runs
+#     `tofu plan -refresh-only -detailed-exitcode -no-color`
+#     and writes the three-valued exit code (0|1|2) to
+#     `.uncharles/state/last_plan_exit`. The wrapper itself exits 0 if the
+#     plan ran (regardless of result) or non-zero only on process-level
+#     failure (signal, missing tofu binary, credential failure).
+#   - `.uncharles/scripts/archive.sh <kind>` archives stdout/stderr and any
+#     plan output under `.uncharles/evidence/<utc_ts>/`, where `<kind>` is
+#     one of `clean`, `drift`, or `error`. Removes
+#     `.uncharles/state/last_plan_exit` and `.uncharles/state/prefetch_done`
+#     on success so the next outer-tick invocation re-probes from scratch.
+
+sensors:
+  # `push_completed` — the most recent run of `WATCH_WORKFLOW` exited
+  # success. When false (CI failing or no run found), the planner cannot
+  # route through any action and uncharles exits with NoPlan. That is a
+  # useful operator signal: "CI is broken, drift cannot be safely probed".
+  - name: push_completed
+    cmd:
+      - sh
+      - -c
+      - |
+        run_status=$(gh run list --workflow="${WATCH_WORKFLOW:-infrastructure.yaml}" \
+          --limit=1 --json status,conclusion \
+          -q '.[0] | .status + ":" + .conclusion' 2>/dev/null) || exit 1
+        [ "$run_status" = "completed:success" ]
+
+  # `lock_file_in_sync` — `.terraform.lock.hcl` matches the providers the
+  # working tree resolves to. Drift here means a provider was bumped on
+  # `main` since the watcher last ran; recovery is `tofu_init` (read-only
+  # provider refresh — no `-upgrade`, by design).
+  - name: lock_file_in_sync
+    cmd: ["tofu", "init", "-lockfile=readonly", "-input=false", "-no-color"]
+
+  # `prefetch_done` — project-specific marker that artifacts referenced by
+  # `tofu plan` (lambda zips, SOPS-decrypted vars, etc.) have been seeded
+  # for this run. Without this, `filebase64sha256()` and friends fail at
+  # plan time and we'd misread that as state drift.
+  - name: prefetch_done
+    cmd: ["test", "-f", ".uncharles/state/prefetch_done"]
+
+  # `plan_clean`, `plan_has_changes`, `plan_errored` — three orthogonal
+  # facts derived from `tofu plan -refresh-only -detailed-exitcode`. The
+  # runtime today only sees binary action exit codes (ADR 0002 flags this
+  # as the headline runtime gap); `tofu_plan_refresh` writes the three-valued
+  # exit to `.uncharles/state/last_plan_exit` and these sensors decode it.
+  # Mutually exclusive: at most one is true at a time.
+  - name: plan_clean
+    cmd:
+      - sh
+      - -c
+      - '[ "$(cat .uncharles/state/last_plan_exit 2>/dev/null)" = "0" ]'
+
+  - name: plan_has_changes
+    cmd:
+      - sh
+      - -c
+      - '[ "$(cat .uncharles/state/last_plan_exit 2>/dev/null)" = "2" ]'
+
+  - name: plan_errored
+    cmd:
+      - sh
+      - -c
+      - '[ "$(cat .uncharles/state/last_plan_exit 2>/dev/null)" = "1" ]'
+
+actions:
+  # Refresh providers and the lock file. `tofu init` here uses readonly
+  # creds and does NOT touch state. `-upgrade` is deliberately omitted —
+  # the watcher must not silently bump provider versions; lock-file
+  # recovery is a separate, approval-gated follow-up (ADR 0002 gap 3).
+  - name: tofu_init
+    cost: 3.0
+    requires: [push_completed]
+    adds: [lock_file_in_sync]
+    cmd: ["tofu", "init", "-lockfile=readonly", "-input=false", "-no-color"]
+
+  # Project-specific prefetch (lambda zips, SOPS decrypt, etc.). The
+  # script no-ops if the marker is fresh enough; idempotency is the
+  # script's responsibility, not the planner's.
+  - name: prefetch_artifacts
+    cost: 2.0
+    requires: [push_completed]
+    adds: [prefetch_done]
+    cmd: [".uncharles/scripts/prefetch.sh"]
+
+  # Drift probe. Wrapper runs `tofu plan -refresh-only -detailed-exitcode`
+  # and writes the exit code to `.uncharles/state/last_plan_exit`, then
+  # exits 0 if the plan ran (regardless of result). Optimistic
+  # `+plan_clean` is corrected next iteration by the three plan_* sensors
+  # reading the marker — same divergence-replan pattern as
+  # `release_watch.yaml`'s `await_deploy`. If the actual result is
+  # `plan_has_changes` or `plan_errored`, the planner reroutes to the
+  # matching `archive_*` action on the next iteration.
+  - name: tofu_plan_refresh
+    cost: 5.0
+    requires: [push_completed, lock_file_in_sync, prefetch_done]
+    adds: [plan_clean]
+    cmd: [".uncharles/scripts/tofu-plan-refresh.sh"]
+
+  # Convergence confirmed. Records "world is converged with `main` as of
+  # <utc_ts>" and exits the loop. The archive script also clears
+  # `last_plan_exit` and `prefetch_done` so the next outer-tick re-probes.
+  - name: archive_clean
+    cost: 1.0
+    requires: [plan_clean]
+    adds: [idle]
+    removes: [plan_clean]
+    cmd: [".uncharles/scripts/archive.sh", "clean"]
+
+  # Drift detected. The watcher does NOT auto-apply or auto-remediate;
+  # drift is surfaced for a human (or a higher-level workflow) to triage.
+  # Setting `idle` lets the watcher exit cleanly; the external wrapper
+  # decides whether to alert based on the archive contents.
+  - name: archive_drift
+    cost: 1.0
+    requires: [plan_has_changes]
+    adds: [idle]
+    removes: [plan_has_changes]
+    cmd: [".uncharles/scripts/archive.sh", "drift"]
+
+  # Plan errored (provider failure, state-schema decay, missing artifact
+  # the prefetch should have seeded). Same disposition as `archive_drift`:
+  # the watcher does not retry — the issue's "self-induced rug-pull"
+  # failure mode is exactly the case where blind retry against
+  # half-mutated state worsens things. Surfaces and exits.
+  - name: archive_error
+    cost: 1.0
+    requires: [plan_errored]
+    adds: [idle]
+    removes: [plan_errored]
+    cmd: [".uncharles/scripts/archive.sh", "error"]
+
+# Goal is `idle`: one of the `archive_*` actions completed and set the
+# marker via its effects. The outer wrapper invokes uncharles again on the
+# next outer tick; cold-start state in that next invocation has neither
+# `last_plan_exit` nor `prefetch_done`, so the planner re-derives the
+# probe path from scratch.
+goal:
+  requires: [idle]

--- a/uncharles/tests/cli.rs
+++ b/uncharles/tests/cli.rs
@@ -234,6 +234,140 @@ fn release_watch_dry_run_emits_expected_schema() {
 }
 
 #[test]
+fn tofu_drift_watch_dry_run_pins_post_apply_watcher_design() {
+    // Pins the design from ADR 0002 (post-apply IaC convergence watcher):
+    // the sensor/action surface, the three-valued plan_* facts, the
+    // archive_* fan-out, and the goal `idle`. Also pins the security
+    // invariant from the ADR's "Confirmation" section by reading the
+    // YAML directly: the watcher must never invoke `tofu apply` and must
+    // never run `tofu init -upgrade`. Both would silently violate the
+    // readonly-creds posture this config commits to.
+    use std::fs;
+
+    let output = Command::new(binary())
+        .arg("--config")
+        .arg(config_path("tofu_drift_watch.yaml"))
+        .arg("--dry-run")
+        .output()
+        .expect("failed to spawn uncharles");
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    let sensor_names: Vec<&str> = parsed["sensors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        sensor_names,
+        vec![
+            "push_completed",
+            "lock_file_in_sync",
+            "prefetch_done",
+            "plan_clean",
+            "plan_has_changes",
+            "plan_errored",
+        ],
+    );
+
+    let action_names: Vec<&str> = parsed["actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        action_names,
+        vec![
+            "tofu_init",
+            "prefetch_artifacts",
+            "tofu_plan_refresh",
+            "archive_clean",
+            "archive_drift",
+            "archive_error",
+        ],
+    );
+
+    let goal_requires: Vec<&str> = parsed["goal"]["requires"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(goal_requires, vec!["idle"]);
+
+    // Each archive_* must remove the plan_* fact it consumes; without
+    // that, a stale plan result from a previous cycle would let the next
+    // invocation skip the probe (tofu_plan_refresh's optimistic +plan_clean
+    // would be already true from cold-start sensor simulation). Guard
+    // against a future config edit silently dropping that effect.
+    for (action, removed) in &[
+        ("archive_clean", "plan_clean"),
+        ("archive_drift", "plan_has_changes"),
+        ("archive_error", "plan_errored"),
+    ] {
+        let entry = parsed["actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["name"] == *action)
+            .unwrap_or_else(|| panic!("action {action} not found"));
+        let removes: Vec<&str> = entry["removes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(
+            removes.contains(removed),
+            "{action} must remove {removed}; got removes={removes:?}",
+        );
+    }
+
+    // Security invariant from ADR 0002: the watcher commits to a
+    // readonly-creds posture. Walk every sensor/action `cmd` and reject
+    // tokens that would silently violate it (`apply` to tofu, `-upgrade`
+    // to init). If a future edit slips either in, this trips loudly so
+    // the posture has to be re-decided in an ADR rather than in a diff.
+    let yaml = fs::read_to_string(config_path("tofu_drift_watch.yaml")).unwrap();
+    let parsed_yaml: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+    let mut all_cmds: Vec<Vec<String>> = Vec::new();
+    for kind in ["sensors", "actions"] {
+        for item in parsed_yaml[kind].as_sequence().into_iter().flatten() {
+            if let Some(cmd) = item["cmd"].as_sequence() {
+                all_cmds.push(
+                    cmd.iter()
+                        .map(|v| v.as_str().unwrap_or_default().to_string())
+                        .collect(),
+                );
+            }
+        }
+    }
+    for cmd in &all_cmds {
+        assert!(
+            !cmd.windows(2).any(|w| w[0] == "tofu" && w[1] == "apply"),
+            "watcher must never run `tofu apply`; readonly-only per ADR 0002. \
+             Offending cmd: {cmd:?}",
+        );
+        for arg in cmd {
+            assert!(
+                !arg.split_whitespace().any(|tok| tok == "-upgrade"),
+                "watcher must not pass `-upgrade` to `tofu init`; silent \
+                 provider bumps violate ADR 0002. Offending cmd: {cmd:?}",
+            );
+        }
+    }
+}
+
+#[test]
 fn execute_loop_drives_podcast_pipeline_end_to_end() {
     // Hermetic e2e for podcast.yaml. Pre-stages a fixture-guids.txt with
     // two GUIDs in a fresh temp dir, runs uncharles, and asserts the full


### PR DESCRIPTION
## Summary

- Lands option (c) from #25: a minimal post-apply IaC convergence watcher config (`uncharles/configs/tofu_drift_watch.yaml`) for one OpenTofu state key. Senses `push_completed` / `lock_file_in_sync` / `prefetch_done` plus the three-valued `plan_clean` / `plan_has_changes` / `plan_errored` derived from `tofu plan -refresh-only -detailed-exitcode`; acts via `tofu_init`, `prefetch_artifacts`, `tofu_plan_refresh`, and three `archive_*` fan-outs; goal is `idle`.
- Adds [ADR 0002](docs/adrs/0002-uncharles-as-post-apply-iac-convergence-watcher.md) capturing the role decision: uncharles is a **post-apply convergence watcher**, not a CI replacement. Readonly credentials only; never auto-applies. The ADR enumerates the six runtime gaps from #25 as follow-up issues so they can be reviewed individually rather than entangled with "should we do this at all?".
- Adds an integration test that pins the design contract: sensor/action surface, the `archive_*`-removes invariant, no `tofu apply` anywhere, no `-upgrade` to `tofu init`. Walks the parsed YAML so future edits that violate the readonly posture trip the test loudly.

## Conventional commit

Type (check one):

- [x] `feat` — new user-visible capability

Scope (crate or area):

`uncharles`

## Breaking changes

None.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual verification: `cargo run -q -p uncharles -- inspect --config uncharles/configs/tofu_drift_watch.yaml` — clean static analysis (no orphan actions, no unreachable goal facts, no dead-end states), exits 0.

## Linked issues

Refs #25 (the issue stays open for the six runtime-gap follow-ups; this PR closes only the "which option do we adopt?" sub-question, captured in ADR 0002).