### PR TITLE
ci(bench): size-aware regression threshold for sub-20ns benches

### DIFF
--- a/.github/scripts/detect-bench-regression.py
+++ b/.github/scripts/detect-bench-regression.py
@@ -4,16 +4,39 @@
 Criterion already prints "Performance has regressed." when a change is
 statistically significant (p < 0.05) and exceeds its (tiny) default noise
 threshold of 1%. On shared CI runners that bar is too sensitive: noise
-alone can push a stable benchmark over it. We layer an additional gate on
-top: only fail if the **lower bound** of the 95% confidence interval
-crosses `threshold_pct` (default 10%).
+alone can push a stable benchmark over it. We layer two gates on top.
 
-Using the lower bound (rather than the mean or upper bound) is the
-"robust regression" gate: a benchmark fails the check only when even the
-optimistic read of the data shows a regression above the threshold. This
-trades sensitivity for false-positive rate — a deliberate choice for
-shared-runner CI where small benches drift by tens of percent under
-neighbour load.
+Gate 1 — robust regression: only fail if the **lower bound** of the 95%
+confidence interval crosses the threshold. Using the lower bound (rather
+than the mean or upper bound) means a bench fails only when even the
+optimistic read of the data shows a regression. This trades sensitivity
+for false-positive rate — a deliberate choice for shared-runner CI where
+small benches drift by tens of percent under neighbour load.
+
+Gate 2 — size-aware threshold: a fixed percentage threshold treats a
+"+25 % regression" on an 8 ns op the same as a "+25 % regression" on an
+8 ms op, but the absolute drift on the 8 ns op (≈ 2 ns) is well within
+the runner's clock-quantum + scheduling jitter, while +25 % on the 8 ms
+op is a real 2 ms slowdown. To compensate, we widen the threshold for
+fast benches:
+
+    effective_threshold_pct = max(base_threshold_pct,
+                                  NOISE_FLOOR_NS / observed_median_ns * 100)
+
+`NOISE_FLOOR_NS` is the absolute drift (in nanoseconds) we treat as
+indistinguishable from runner jitter. At 2 ns it's roughly two CPU clock
+periods plus typical Linux scheduling slack — small enough to pass real
+slowdowns through, large enough to absorb the kind of background-process
+hiccup that shows up as a 25 % regression on a sub-30 ns bench.
+
+Worked examples (with NOISE_FLOOR_NS = 2.0 and base = 10.0 %):
+    8 ns bench   → max(10.0, 25.0) = 25.0 %
+    20 ns bench  → max(10.0, 10.0) = 10.0 %
+    100 ns bench → max(10.0, 2.0)  = 10.0 %
+    1 µs bench   → max(10.0, 0.2)  = 10.0 %
+
+In other words: anything ≥ 20 ns observed median uses the base threshold
+unchanged; smaller benches get a soft cap derived from absolute drift.
 
 Usage:
     detect-bench-regression.py <criterion-log> [threshold-pct]
@@ -33,8 +56,53 @@ from pathlib import Path
 CHANGE_RE = re.compile(
     r"change:\s*\[\s*([+\-\d.]+)\s*%\s+([+\-\d.]+)\s*%\s+([+\-\d.]+)\s*%\s*\]"
 )
+# Criterion emits e.g. "time:   [10.123 ns 10.456 ns 10.789 ns]". Units
+# vary across benches (ns / µs / us / ms / s). Capture the median (middle)
+# value with its unit so we can convert to nanoseconds for the size-aware
+# threshold.
+TIME_RE = re.compile(
+    r"time:\s*\[\s*"
+    r"[\d.]+\s*(?:ns|µs|us|ms|s)\s+"
+    r"([\d.]+)\s*(ns|µs|us|ms|s)\s+"
+    r"[\d.]+\s*(?:ns|µs|us|ms|s)\s*\]"
+)
 REGRESSED_VERDICT = "Performance has regressed"
 BENCH_HEADER_RE = re.compile(r"^Benchmarking (?P<name>.+?): Analyzing\s*$", re.MULTILINE)
+
+# Absolute drift below which we treat a regression as runner jitter
+# rather than a real slowdown. See module docstring for the rationale.
+NOISE_FLOOR_NS = 2.0
+
+UNIT_TO_NS: dict[str, float] = {
+    "ns": 1.0,
+    "µs": 1_000.0,
+    "us": 1_000.0,
+    "ms": 1_000_000.0,
+    "s": 1_000_000_000.0,
+}
+
+
+def parse_median_ns(body: str) -> float | None:
+    """Pull the median time out of criterion's `time: [low med high]` line
+    and convert to nanoseconds. Returns `None` if the line is missing
+    (which would indicate either a parsing failure or a bench format
+    change worth investigating)."""
+    match = TIME_RE.search(body)
+    if match is None:
+        return None
+    value = float(match.group(1))
+    unit = match.group(2)
+    return value * UNIT_TO_NS[unit]
+
+
+def effective_threshold(base_pct: float, observed_ns: float | None) -> float:
+    """Size-aware threshold: widen for fast benches whose absolute drift
+    is dominated by clock-quantum + scheduling jitter. See module
+    docstring for the formula."""
+    if observed_ns is None or observed_ns <= 0.0:
+        return base_pct
+    floor_pct = NOISE_FLOOR_NS / observed_ns * 100.0
+    return max(base_pct, floor_pct)
 
 
 def main() -> int:
@@ -51,7 +119,7 @@ def main() -> int:
         return 2
 
     try:
-        threshold = float(sys.argv[2]) if len(sys.argv) == 3 else 10.0
+        base_threshold = float(sys.argv[2]) if len(sys.argv) == 3 else 10.0
     except ValueError:
         print(f"error: threshold must be a number, got {sys.argv[2]!r}", file=sys.stderr)
         return 2
@@ -69,7 +137,8 @@ def main() -> int:
         )
         return 2
 
-    failures: list[tuple[str, float, float, float]] = []
+    failures: list[tuple[str, float, float, float, float]] = []
+    softened: list[tuple[str, float, float, float, float, float]] = []
     total = 0
     flagged_by_criterion = 0
 
@@ -82,39 +151,63 @@ def main() -> int:
         lower = float(match.group(1))
         median = float(match.group(2))
         upper = float(match.group(3))
+        observed_ns = parse_median_ns(body)
+        threshold = effective_threshold(base_threshold, observed_ns)
         criterion_regressed = REGRESSED_VERDICT in body
         if criterion_regressed:
             flagged_by_criterion += 1
             # Robust gate: even the optimistic (lower) bound of the
-            # 95% CI must exceed the threshold for this to count as a
-            # regression. Tight intervals around a real slowdown will
-            # clear this; wide intervals from runner jitter (where
-            # only the upper bound looks scary) will not.
+            # 95% CI must exceed the (size-aware) threshold for this
+            # to count as a regression.
             if lower > threshold:
-                failures.append((name, lower, median, upper))
+                failures.append((name, lower, median, upper, threshold))
+            elif lower > base_threshold:
+                # Would have failed under the flat base threshold but
+                # is absorbed by the size-aware widening — surface it
+                # so the gate's behaviour is auditable in the log.
+                softened.append(
+                    (name, lower, median, upper, threshold, observed_ns or 0.0)
+                )
 
     print(
         f"Parsed {total} benchmark(s); criterion flagged {flagged_by_criterion}; "
-        f"{len(failures)} exceed threshold of {threshold}% on the lower CI bound."
+        f"{len(failures)} exceed threshold (base {base_threshold}%, "
+        f"size-aware floor {NOISE_FLOOR_NS} ns)."
     )
+
+    if softened:
+        print(
+            "\nSize-aware widening absorbed these regressions "
+            "(would have failed at flat threshold):"
+        )
+        for name, lower, median, upper, eff, ns in softened:
+            print(
+                f"  - {name}: median +{median:.1f}% "
+                f"(CI [+{lower:.1f}%, +{upper:.1f}%]) — "
+                f"observed {ns:.1f} ns, threshold widened to {eff:.1f}%"
+            )
 
     if failures:
         print("", file=sys.stderr)
-        print("Regressions exceeding the threshold (lower CI bound > threshold):", file=sys.stderr)
-        for name, lower, median, upper in failures:
+        print(
+            "Regressions exceeding the threshold (lower CI bound > threshold):",
+            file=sys.stderr,
+        )
+        for name, lower, median, upper, eff in failures:
             print(
                 f"  - {name}: median +{median:.1f}% "
-                f"(CI [+{lower:.1f}%, +{upper:.1f}%])",
+                f"(CI [+{lower:.1f}%, +{upper:.1f}%]) — threshold {eff:.1f}%",
                 file=sys.stderr,
             )
         print(
-            f"\nFAIL: {len(failures)} benchmark(s) regressed beyond {threshold}% "
-            f"on the lower CI bound.",
+            f"\nFAIL: {len(failures)} benchmark(s) regressed beyond their "
+            f"size-aware threshold (base {base_threshold}%, "
+            f"floor {NOISE_FLOOR_NS} ns).",
             file=sys.stderr,
         )
         return 1
 
-    print(f"OK: no benchmark regressed beyond {threshold}% on the lower CI bound.")
+    print(f"OK: no benchmark regressed beyond its size-aware threshold.")
     return 0
 
 


### PR DESCRIPTION
## Summary

- Adds a size-aware floor to `.github/scripts/detect-bench-regression.py`: `effective_threshold = max(base_pct, NOISE_FLOOR_NS / observed_ns × 100)`. Anything ≥ 20 ns observed median uses the base threshold (10 %) unchanged; faster benches get a soft cap derived from absolute drift, so a +18 % "regression" on an 8 ns op is correctly read as runner jitter.
- This PR is **option 2 of a 2-step plan** to reduce bench-gate noise. Option 1 (per-bench batching to push nano-benches out of the clock-quantum band) lands separately so this PR has zero bench-code changes and zero false-positive risk on its own bench run.

## Why split

Combining batching and threshold-widening in one PR would trigger a +3000 % "regression" on the bench gate the moment this PR ran, because base (unbatched 8 ns) and head (batched 256 ns) measure different quantities. Splitting:

- **PR #40 (this)**: script-only change. Bench numbers unchanged, no false positive.
- **PR (follow-up)**: bench batching with renamed bench IDs (`_x32` suffix). Renamed benches have no baseline → criterion skips comparison → no false positive.

Both end states deliver the same noise reduction; the split sequences them safely.

## Conventional commit

Type: `ci`. Scope: `bench`.

## Breaking changes

None. The script's exit codes, regex matching, and CLI signature are unchanged. New behaviour is additive: regressions absorbed by size-aware widening are reported in stdout as an audit log.

## How to read the formula

`NOISE_FLOOR_NS = 2.0` is the absolute drift (nanoseconds) we treat as indistinguishable from runner jitter — roughly two CPU clock periods plus typical Linux scheduling slack on Azure-hosted shared runners. Worked examples:

```
8 ns bench   → max(10.0, 25.0) = 25.0 %
20 ns bench  → max(10.0, 10.0) = 10.0 %
100 ns bench → max(10.0, 2.0)  = 10.0 %
1 µs bench   → max(10.0, 0.2)  = 10.0 %
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] Synthetic-log smoke tests:
  - real regressions on 250 ns / 800 ns / 4.7 ms benches at +20–37 % → exits 1, all 3 reported
  - jitter on 7.8 ns bench at +18 % → exits 0, reported in audit log as "size-aware widening absorbed"
  - real regression on 30.3 ns bench at +100 % → exits 1, reported normally (well above widened threshold)

## Linked issues

Refs #24 (bench fragility on shared runners — same-machine pin landed in #29; this is the next layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)