### PR TITLE
feat(uncharles): add value-carrying facts via sensor stdout capture

### DIFF
--- a/docs/adrs/0003-value-carrying-facts-runtime-side.md
+++ b/docs/adrs/0003-value-carrying-facts-runtime-side.md
@@ -1,0 +1,245 @@
+---
+status: accepted
+date: 2026-05-03
+decision-makers: ["@leopepe"]
+consulted: []
+informed: []
+---
+
+# Value-carrying facts live in the uncharles runtime, not in goap-planner's State
+
+## Context and Problem Statement
+
+`goap-planner`'s `State` is Boolean: a fact is either present or absent. Three
+real configs (`release_watch.yaml`, `merge_gate.yaml`, `podcast.yaml`) and the
+`tofu_drift_watch.yaml` watcher landed alongside ADR 0002 all reach for the
+same workaround — write a string ("commit SHA", "PR number", "episode GUID",
+"three-valued plan exit code") to `.uncharles/state/<thing>` and round-trip it
+through `cat` / `test` from action commands and downstream sensors. The
+pattern is consistent enough to commit to a first-class abstraction. The
+question this ADR settles is **where the values live and what surface they
+expose**, given two distinct interpretations of the recommendation in #18:
+extending `goap-planner`'s `State` to carry values alongside facts (option a
+as worded), or keeping the planner Boolean and routing values entirely
+through the `uncharles` runtime. Refs #18, refs ADR 0002.
+
+## Decision Drivers
+
+* **Hot-path sensitivity in `goap-planner`.** `State::signature`,
+  `State::contains`, `Action::applicable`, and the BFS exploration loop are
+  called millions of times during planning. Any extra field on `State` —
+  even one the planner explicitly ignores — adds clone cost, hash cost, and
+  cache pressure. The crate's own `CLAUDE.md` lists those exact methods as
+  bench-trigger conditions.
+* **Layering.** The workspace `CLAUDE.md` is explicit: `goap-planner` is
+  pure CPU work over `State` / `Action` / `Goal`. I/O, side effects, and
+  *anything stdout-shaped* belong in `uncharles`. Capturing a sensor's
+  stdout into a value is exactly the kind of thing that should not push
+  down into the planner.
+* **Minimum new public surface.** Every field added to a public type in
+  `goap-planner` is a back-compat commitment. If values can flow through
+  `uncharles` end-to-end without `goap-planner` ever seeing them, the
+  planner's API stays unchanged and we avoid creating a deprecation surface
+  later.
+* **Use cases all live in the runtime anyway.** The three sidecar-file
+  workarounds in existing configs all flow value → action command (via
+  shell). They never need the planner to *reason* about the value (the
+  recommendation in #18 is explicit: planner ignores values during BFS).
+  If the planner doesn't read the value, there's no reason to put the
+  value in the planner.
+* **Forward compatibility with the watcher's three-valued plan exit.**
+  ADR 0002's drift-watcher uses a marker file plus three Boolean sensors
+  (`plan_clean` / `plan_has_changes` / `plan_errored`) to encode one
+  three-valued integer. A value-carrying-fact mechanism that lives in
+  `uncharles` retires that workaround directly, with no `goap-planner`
+  change required.
+
+## Considered Options
+
+* **Option A — Extend `goap-planner::State` to carry values the planner
+  ignores during BFS.** The `Hash`/`PartialEq` impls treat `State` as
+  Boolean; an additional `BTreeMap<String, String>` field carries values.
+  `uncharles` reads/writes that field and injects values into action
+  commands as env vars.
+* **Option B — Values live entirely in the `uncharles` runtime, alongside
+  `State` but never inside it.** The planner stays untouched. `uncharles`
+  carries a `Values` map (`BTreeMap<String, String>`) through the
+  sense → plan → execute loop, populated by sensor stdout capture
+  (`capture: stdout` on `SensorSpec`) and consumed by env-var injection
+  (`UNCHARLES_FACT_<NAME>=<value>`) when invoking action commands.
+* **Option C — Keep state Boolean and standardise the sidecar-file pattern
+  in `uncharles` as a documented convention** (with a small library helper
+  for read/write). No runtime data structure; the disk is the source of
+  truth.
+* **Option D — Promote sensors and actions to a templating / parameter
+  system**, where each sensor produces a fact-with-value and actions consume
+  by name through a templating layer.
+
+## Decision Outcome
+
+Chosen option: **"Option B — values live in the `uncharles` runtime, not in
+`goap-planner::State`"**, because it satisfies every concrete use case
+without changing the planner's hot-path footprint by a single byte. The
+planner stays Boolean; the runtime grows one `BTreeMap<String, String>` and
+two narrow extension points (a `capture` field on `SensorSpec`, env-var
+injection in `execute_action`). The mechanism is invisible to anyone who
+doesn't opt in: existing configs continue to work bit-for-bit, and
+benchmarks should report no movement on `goap-planner`'s headline numbers.
+
+The runtime contract is:
+
+* **Capture.** A sensor opts into value capture by setting `capture: stdout`
+  in YAML (the only variant in v1; `stderr` and structured forms are future
+  work). When the sensor's command exits successfully, its trimmed stdout is
+  stored in the runtime's `Values` map under the sensor's `name`. The
+  `Hash`/`PartialEq` of `goap-planner::State` is *not* affected — the
+  Boolean fact `<sensor.name>` is added to `State` as before.
+* **Lifetime within a cycle.** Values live for the duration of one
+  `uncharles` invocation. They are populated by sensors at each iteration's
+  top and consumed by action commands during the same iteration. A
+  successful sensor that re-runs in a later iteration overwrites its prior
+  value. A sensor that fails (and whose default failure effect removes the
+  fact) drops the value.
+* **Atomic remove.** When an action's `removes` list (or a sensor's
+  `on_failure.remove` list) clears a fact, the corresponding value is
+  dropped from `Values` in the same operation. Fact and value are one unit;
+  there is no "removed-fact-but-kept-value" state.
+* **Env-var injection.** When `uncharles` invokes an action command, every
+  fact in the action's `requires` list that has a matching value in
+  `Values` is exported as `UNCHARLES_FACT_<UPPER_SNAKE_CASE_NAME>=<value>`
+  on the child process's environment. Facts without values produce no env
+  var (not an empty one). `forbids` facts are by definition absent and so
+  never have values to inject.
+* **Cardinality.** Single-value per fact. Lists are not modelled — scripts
+  that need a list use newline-delimited stdout.
+* **Persistence across cycles.** Out of scope for this ADR. v1 lives within
+  one invocation. The eventual `--watch` mode (#17) will need a decision on
+  cross-cycle persistence; that is a separate ADR keyed off the same
+  abstraction.
+
+### Consequences
+
+* Good, because `goap-planner` is unchanged — no clone, hash, or cache cost
+  added to the BFS hot path. The bench gate stays meaningful.
+* Good, because the YAML schema gains a single optional field on
+  `SensorSpec` (`capture: stdout`). Existing configs are bit-for-bit
+  compatible; nothing is breaking.
+* Good, because the `tofu_drift_watch.yaml` config's wrapper-script trick
+  (write three-valued exit to a marker file, three Boolean sensors decode
+  it) becomes a one-line `capture: stdout` annotation in a follow-up PR.
+  ADR 0002's headline "Bad, because" point on shell-in-config retires.
+* Good, because env-var injection is the lowest-friction way to surface
+  values to shell commands — every existing action `cmd` in every existing
+  config can read it without touching argv parsing or templating.
+* Bad, because the planner cannot reason about values. A future feature
+  request for "plan based on the *value* of a fact" (e.g. "this action only
+  applies when `target_sha` matches `current_sha`") is not expressible in
+  this design. Such a feature would need a new ADR and almost certainly an
+  Option-A-shaped change to `goap-planner`.
+* Bad, because values are runtime-only and don't survive across
+  invocations. A watcher that probes "did the value change since last
+  cycle?" must either persist its own marker (the existing pattern stays
+  available) or wait for cross-cycle persistence (out of scope).
+* Bad, because the env-var name mapping (`my-fact.name` →
+  `UNCHARLES_FACT_MY_FACT_NAME`) is lossy: two distinct fact names that
+  collapse to the same env-var name would clash. We accept this and
+  document the mapping; configs that hit the collision are doing
+  something exotic enough that a YAML-load-time error is the right
+  remediation if it ever bites.
+
+### Confirmation
+
+Compliance is verified by three gates:
+
+1. **`goap-planner` benchmarks** — `cargo bench -p goap-planner --bench
+   performance -- --save-baseline pre-issue-18` and the same with
+   `--baseline pre-issue-18` after the change. The `pre-` and `post-`
+   numbers must agree within criterion's noise band; the CI gate
+   (`.github/workflows/bench.yml`, 10 % robust-regression threshold) is
+   the long-term enforcement.
+2. **Unit and integration tests** — `cargo test -p uncharles` covers
+   `SensorSpec.capture` parsing (presence, absence, unknown variant
+   rejected), the `Values` lifecycle (sensor success populates, action
+   `removes` clears, sensor failure clears), env-var injection
+   (`UNCHARLES_FACT_<NAME>` set for every value-bearing `requires` fact;
+   absent facts → no var), and end-to-end flow through `run_loop`.
+3. **`uncharles inspect` static analysis** — the new `capture` field is
+   ignored by inspect's BFS (which is goap-planner-shaped); existing
+   configs still emit identical inspection reports. Verified by re-running
+   inspect on every checked-in config and diffing the JSON output.
+
+## Pros and Cons of the Options
+
+### Option A — extend `State` with a values field
+
+* Good, because values are co-located with facts in the planner type.
+* Good, because if a future feature does want value-aware planning, the
+  value is already there.
+* Bad, because every state clone in BFS pays the (cold but real) cost of
+  cloning a `BTreeMap` even if it's empty. State allocation is in the
+  hottest part of the planner.
+* Bad, because the planner's public API gains a field that exists only for
+  another crate's use case. That's leaky layering, and the workspace
+  CLAUDE.md is explicit that runtime concerns belong in `uncharles`.
+* Bad, because the bench gate becomes harder to interpret: a no-op-feature
+  PR could move headline numbers a few percent purely from cache layout
+  changes, and disambiguating "real regression" from "Option A overhead"
+  consumes review time forever.
+
+### Option B — values live in `uncharles` (chosen)
+
+* Good, because `goap-planner` is bit-for-bit unchanged. The bench gate
+  keeps its full signal.
+* Good, because the surface is small and orthogonal — opt-in YAML field,
+  one runtime data structure, one env-var convention.
+* Good, because every existing action `cmd` in every existing config can
+  consume values without modification.
+* Neutral, because values cannot influence planning. This is a deliberate
+  scope cut: every observed use case is "value flows to action command",
+  not "planner branches on value".
+* Bad, because if value-aware planning ever does become a requirement, this
+  ADR will need to be superseded and the runtime values map migrated into
+  `goap-planner::State`. That migration is mechanical (move a field, update
+  call sites) but non-trivial.
+
+### Option C — sidecar-file convention
+
+* Good, because zero code change.
+* Bad, because every config keeps reinventing the read/write idiom; the
+  abstraction tax is paid forever rather than once.
+* Bad, because the disk is the synchronisation point, which means every
+  read is a `cat` subshell and every write is a `tee`. Performance is
+  fine; cognitive overhead is not.
+* Bad, because there is no machine-readable surface for tooling
+  (`uncharles inspect`, future debugging UIs) to discover what values
+  exist.
+
+### Option D — templating
+
+* Good, because it scales to more complex parameterisation than env vars.
+* Bad, because it is a much larger surface than this problem needs. Three
+  configs that want to pass a SHA to a shell command do not justify a
+  templating system.
+* Bad, because templating in a sense → plan → act loop tangles with
+  replan semantics in ways that are hard to reason about (when does the
+  template re-evaluate?). Env vars are a clean blast radius: each action
+  invocation gets a fresh environment.
+
+## More Information
+
+* **Driving issue**: #18 (status `accepted`). This ADR closes the design
+  half; the implementing PR closes the issue itself.
+* **Composes with ADR 0002**: the drift-watcher's `plan_clean` /
+  `plan_has_changes` / `plan_errored` workaround retires once a follow-up
+  config edit replaces it with a single `plan_result` fact carrying the
+  exit code as its value. Tracked as part of the ADR 0002 follow-up gaps.
+* **Composes with #17 (`--watch` mode)**: cross-cycle persistence of
+  values is deliberately out of scope for v1. The `--watch` ADR will need
+  to settle "does a value survive between watch ticks?" as part of its
+  loop semantics.
+* **Trigger to revisit**: the first concrete request for **value-aware
+  planning** ("the planner should treat states differing only in a value
+  as distinct" or "this action only applies when fact `X` has value
+  matching pattern `Y`"). At that point, this ADR is superseded and
+  `State` grows the values field. Until that request appears, the
+  layering decision stays where it is.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -15,6 +15,7 @@ next free number.
 | ---- | ----- | ------ | ---- |
 | 0001 | [Relax `main` ruleset for solo-contributor workflow](./0001-relax-main-ruleset-for-solo-contributor.md) | accepted | 2026-05-02 |
 | 0002 | [Use uncharles as a post-apply IaC convergence watcher, not a CI replacement](./0002-uncharles-as-post-apply-iac-convergence-watcher.md) | accepted | 2026-05-03 |
+| 0003 | [Value-carrying facts live in the uncharles runtime, not in goap-planner's State](./0003-value-carrying-facts-runtime-side.md) | accepted | 2026-05-03 |
 
 ## Status legend
 

--- a/goap-planner/docs/bench-2026-05-03-issue-18.txt
+++ b/goap-planner/docs/bench-2026-05-03-issue-18.txt
@@ -1,0 +1,212 @@
+planning/chain/steps/5  time:   [3.2182 µs 3.2335 µs 3.2483 µs]
+                        change: [-1.3145% -0.9665% -0.5678%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+planning/chain/steps/10 time:   [5.9177 µs 5.9447 µs 5.9730 µs]
+                        change: [-0.0570% +0.5071% +1.0776%] (p = 0.07 > 0.05)
+                        No change in performance detected.
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) low mild
+  2 (2.00%) high mild
+planning/chain/steps/20 time:   [11.619 µs 11.650 µs 11.681 µs]
+                        change: [+1.2841% +1.6558% +2.0604%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+planning/chain/steps/50 time:   [32.415 µs 32.523 µs 32.641 µs]
+                        change: [+0.8683% +1.2027% +1.5626%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 8 outliers among 100 measurements (8.00%)
+  4 (4.00%) low mild
+  4 (4.00%) high mild
+
+planning/wide/branches/8
+                        time:   [10.221 µs 10.271 µs 10.322 µs]
+                        change: [-0.1196% +0.3894% +0.9393%] (p = 0.14 > 0.05)
+                        No change in performance detected.
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+planning/wide/branches/32
+                        time:   [50.668 µs 51.074 µs 51.422 µs]
+                        change: [+3.3512% +3.9242% +4.5484%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+planning/wide/branches/128
+                        time:   [357.58 µs 358.62 µs 359.80 µs]
+                        change: [+3.0073% +3.3757% +3.7649%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  4 (4.00%) high mild
+  2 (2.00%) high severe
+planning/wide/branches/512
+                        time:   [5.4232 ms 5.4340 ms 5.4455 ms]
+                        change: [+1.3497% +1.5923% +1.8488%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 5 outliers among 100 measurements (5.00%)
+  5 (5.00%) high mild
+
+planning/redundant_paths/paths/2
+                        time:   [3.2156 µs 3.2428 µs 3.2726 µs]
+                        change: [+3.4442% +4.1201% +4.8083%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+planning/redundant_paths/paths/4
+                        time:   [5.8595 µs 5.8789 µs 5.9007 µs]
+                        change: [+2.1023% +2.5270% +2.9862%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+planning/redundant_paths/paths/8
+                        time:   [11.338 µs 11.379 µs 11.420 µs]
+                        change: [+1.7386% +2.1429% +2.5408%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 5 outliers among 100 measurements (5.00%)
+  4 (4.00%) low mild
+  1 (1.00%) high mild
+planning/redundant_paths/paths/16
+                        time:   [23.502 µs 23.583 µs 23.659 µs]
+                        change: [+0.8043% +1.1895% +1.5560%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 4 outliers among 100 measurements (4.00%)
+  1 (1.00%) low severe
+  3 (3.00%) low mild
+planning/redundant_paths/paths/32
+                        time:   [51.295 µs 51.516 µs 51.729 µs]
+                        change: [+0.4193% +0.8410% +1.2644%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+
+planning/boundaries/already_satisfied_x32
+                        time:   [204.35 ns 204.92 ns 205.60 ns]
+                        change: [+1.0890% +1.4551% +1.8405%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low mild
+  5 (5.00%) high mild
+planning/boundaries/unreachable
+                        time:   [3.5267 µs 3.5411 µs 3.5553 µs]
+                        change: [+0.7989% +1.2691% +1.6993%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) low severe
+  1 (1.00%) low mild
+
+ops/state/contains_hit_x32
+                        time:   [172.13 ns 174.99 ns 178.83 ns]
+                        change: [+1.3056% +2.4275% +3.8570%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 19 outliers among 100 measurements (19.00%)
+  7 (7.00%) low mild
+  6 (6.00%) high mild
+  6 (6.00%) high severe
+ops/state/contains_miss_x32
+                        time:   [87.468 ns 87.539 ns 87.611 ns]
+                        change: [-0.3101% -0.1215% +0.0666%] (p = 0.21 > 0.05)
+                        No change in performance detected.
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) high mild
+  5 (5.00%) high severe
+ops/state/insert        time:   [41.350 ns 42.539 ns 43.635 ns]
+                        change: [-13.968% -8.8899% -3.9047%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 4 outliers among 100 measurements (4.00%)
+  4 (4.00%) high mild
+ops/state/from_facts/1  time:   [33.537 ns 33.672 ns 33.817 ns]
+                        change: [+1.1031% +1.5089% +1.9079%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+ops/state/from_facts/10 time:   [222.85 ns 224.71 ns 226.72 ns]
+                        change: [+2.6434% +3.8372% +5.0411%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+ops/state/from_facts/100
+                        time:   [2.2210 µs 2.2301 µs 2.2391 µs]
+                        change: [+0.6453% +1.2896% +1.9141%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 5 outliers among 100 measurements (5.00%)
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+
+ops/action/applicable_met_x32
+                        time:   [534.36 ns 536.38 ns 538.38 ns]
+                        change: [+0.4924% +1.0640% +1.6679%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) low mild
+  1 (1.00%) high mild
+ops/action/applicable_unmet_x32
+                        time:   [455.94 ns 459.14 ns 462.30 ns]
+                        change: [-0.3840% +0.1810% +0.7599%] (p = 0.55 > 0.05)
+                        No change in performance detected.
+ops/action/apply        time:   [127.36 ns 127.84 ns 128.35 ns]
+                        change: [+1.4783% +1.8788% +2.2649%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) low mild
+  2 (2.00%) high mild
+
+ops/goal/trivial_one_required_x32
+                        time:   [202.09 ns 202.72 ns 203.35 ns]
+                        change: [+1.1366% +1.5580% +1.9822%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) low mild
+  1 (1.00%) high mild
+ops/goal/compound_10_req_10_forbid_x32
+                        time:   [2.4383 µs 2.4461 µs 2.4545 µs]
+                        change: [-6.5734% -0.5596% +3.0227%] (p = 0.85 > 0.05)
+                        No change in performance detected.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+ops/goal/unmet_required_x32
+                        time:   [116.24 ns 116.42 ns 116.61 ns]
+                        change: [+2.4160% +2.8116% +3.2189%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 5 outliers among 100 measurements (5.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  1 (1.00%) high mild
+  2 (2.00%) high severe
+
+concurrent_plans/sequential_64
+                        time:   [767.22 µs 769.56 µs 772.10 µs]
+                        change: [+4.4663% +4.9669% +5.4584%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) low mild
+concurrent_plans/parallel_64_rayon
+                        time:   [149.64 µs 151.04 µs 153.04 µs]
+                        change: [+1.2396% +2.0484% +2.8049%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 11 outliers among 100 measurements (11.00%)
+  2 (2.00%) low mild
+  5 (5.00%) high mild
+  4 (4.00%) high severe
+concurrent_plans/parallel_rayon/8
+                        time:   [54.032 µs 54.566 µs 55.128 µs]
+                        change: [+3.5531% +4.9502% +6.4926%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 5 outliers among 100 measurements (5.00%)
+  5 (5.00%) high mild
+concurrent_plans/parallel_rayon/32
+                        time:   [98.146 µs 98.638 µs 99.155 µs]
+                        change: [+0.4966% +1.1586% +1.8536%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 7 outliers among 100 measurements (7.00%)
+  1 (1.00%) low mild
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+concurrent_plans/parallel_rayon/128
+                        time:   [234.10 µs 235.20 µs 236.55 µs]
+                        change: [+3.2781% +4.0264% +4.8442%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 6 outliers among 100 measurements (6.00%)
+  3 (3.00%) high mild
+  3 (3.00%) high severe
+

--- a/goap-planner/docs/perf-comparison-2026-05-03.md
+++ b/goap-planner/docs/perf-comparison-2026-05-03.md
@@ -1,0 +1,107 @@
+# Performance comparison — 2026-05-03 (issue #18 / ADR 0003)
+
+This run validates that ADR 0003's value-carrying-fact mechanism, implemented
+in PR closing #18, has **no measurable impact** on `goap-planner` — the
+crate's source under `src/` is byte-identical between the baseline and head
+runs. The entire feature lives in `uncharles`; the planner's `State`,
+`Action`, `Goal`, and `Planner::plan` are unchanged.
+
+## Why capture it
+
+1. **Honour the workspace rule.** `docs/performance-tests.md` requires a
+   numerical comparison for any change that *could* affect runtime
+   performance. Even when the expectation is "no movement", the comparison
+   is the evidence.
+2. **Establish a same-machine noise floor for this branch.** The 2026-05-02
+   validation rerun (also against unchanged source) measured ±5 % drift on
+   the same hardware. Re-confirming that floor on this branch makes future
+   regression triage easier.
+3. **Pin the ADR's confirmation gate.** ADR 0003 commits to "the planner
+   stays Boolean; benchmarks should report no movement on `goap-planner`'s
+   headline numbers" as one of three confirmation criteria. This file is
+   the artifact for that gate.
+
+## Setup
+
+- **Date:** 2026-05-03
+- **Profile:** release
+  - Baseline: `cargo bench -p goap-planner --bench performance -- --save-baseline pre-issue-18`
+  - Head:     `cargo bench -p goap-planner --bench performance -- --baseline pre-issue-18`
+- **Criterion settings:** defaults — 3 s warm-up, 5 s measurement, 100 samples
+- **Platform:** macOS Darwin 25.3.0
+- **Raw log:** [`bench-2026-05-03-issue-18.txt`](./bench-2026-05-03-issue-18.txt)
+- **Source delta in `goap-planner/src/`:** none (zero lines changed)
+- **Source delta in `uncharles/src/`:** `SensorSpec.capture` field, `Values`
+  type alias, env-var injection in `execute_action`, `Outcome.values` and
+  `LoopEvent::Sensed.values` for observability. None of those run during
+  `goap-planner` benches.
+
+## Results
+
+All 31 individual benches. Δ is `(head − baseline) / baseline × 100` from
+criterion's reported change point estimate. Negative is faster, positive is
+slower. Markers: `* ` ≥ 5 % drift, `!!` ≥ 10 % drift. The CI regression gate
+(`detect-bench-regression.py`, `REGRESSION_THRESHOLD_PCT=10`) fires only on
+robust regressions ≥ 10 %; nothing here approaches that.
+
+| Bench | Head (median) | Δ | Verdict |
+|---|---:|---:|---|
+| planning/chain/steps/5 | 3.23 µs | -1.0 % | improved (noise) |
+| planning/chain/steps/10 | 5.94 µs | +0.5 % | flat (p = 0.07) |
+| planning/chain/steps/20 | 11.65 µs | +1.7 % | regressed (within noise) |
+| planning/chain/steps/50 | 32.52 µs | +1.2 % | regressed (within noise) |
+| planning/wide/branches/8 | 10.27 µs | +0.4 % | flat (p = 0.14) |
+| planning/wide/branches/32 | 51.07 µs | +3.9 % | regressed (within noise) |
+| planning/wide/branches/128 | 358.62 µs | +3.4 % | regressed (within noise) |
+| planning/wide/branches/512 | 5.43 ms | +1.6 % | regressed (within noise) |
+| planning/redundant_paths/paths/2 | 3.24 µs | +4.1 % | regressed (within noise) |
+| planning/redundant_paths/paths/4 | 5.88 µs | +2.5 % | regressed (within noise) |
+| planning/redundant_paths/paths/8 | 11.38 µs | +2.1 % | regressed (within noise) |
+| planning/redundant_paths/paths/16 | 23.58 µs | +1.2 % | regressed (within noise) |
+| planning/redundant_paths/paths/32 | 51.52 µs | +0.8 % | regressed (within noise) |
+| planning/boundaries/already_satisfied_x32 | 205 ns | +1.5 % | regressed (within noise) |
+| planning/boundaries/unreachable | 3.54 µs | +1.3 % | regressed (within noise) |
+| ops/state/contains_hit_x32 | 175 ns | +2.4 % | regressed (within noise) |
+| ops/state/contains_miss_x32 | 87.5 ns | -0.1 % | flat (p = 0.21) |
+| ops/state/insert | 42.5 ns | -8.9 % | improved (noise outlier) |
+| ops/state/from_facts/1 | 33.7 ns | +1.5 % | regressed (within noise) |
+| ops/state/from_facts/10 | 225 ns | +3.8 % | regressed (within noise) |
+| ops/state/from_facts/100 | 2.23 µs | +1.3 % | regressed (within noise) |
+| ops/action/applicable_met_x32 | 536 ns | +1.1 % | regressed (within noise) |
+| ops/action/applicable_unmet_x32 | 459 ns | +0.2 % | flat (p = 0.55) |
+| ops/action/apply | 128 ns | +1.9 % | regressed (within noise) |
+| ops/goal/trivial_one_required_x32 | 203 ns | +1.6 % | regressed (within noise) |
+| ops/goal/compound_10_req_10_forbid_x32 | 2.45 µs | -0.6 % | flat (p = 0.85) |
+| ops/goal/unmet_required_x32 | 116 ns | +2.8 % | regressed (within noise) |
+| concurrent_plans/sequential_64 | 770 µs | `* ` +5.0 % | regressed (within noise) |
+| concurrent_plans/parallel_64_rayon | 151 µs | +2.0 % | regressed (within noise) |
+| concurrent_plans/parallel_rayon/8 | 54.6 µs | `* ` +5.0 % | regressed (within noise) |
+| concurrent_plans/parallel_rayon/32 | 98.6 µs | +1.2 % | regressed (within noise) |
+| concurrent_plans/parallel_rayon/128 | 235 µs | +4.0 % | regressed (within noise) |
+
+## Interpretation
+
+- **No bench crosses the 10 % CI gate.** The largest reported regressions are
+  +5.0 % (`concurrent_plans/sequential_64`, `concurrent_plans/parallel_rayon/8`).
+  The CI's robust regression detector requires the **lower bound** of the
+  confidence interval to clear 10 %; both of these have lower bounds at
+  +3.5 % and +3.6 % respectively, well below the gate.
+- **The `+ ~2-5 %` skew is consistent with same-machine, same-source drift.**
+  The 2026-05-02 validation rerun (which also benched unchanged source against
+  itself) reported a similar magnitude of drift, biased the *other* direction
+  (mostly negative). Build-to-build drift on this hardware sits in the ±5 %
+  band; nothing here is signal.
+- **The single outlier — `ops/state/insert: -8.9 %` — is noise, not a real
+  improvement.** No code path involved in `State::insert` was touched. The
+  bench is a sub-50 ns single-call canary subject to the documented absolute
+  jitter floor described in `docs/performance-tests.md`'s "Sub-50ns benches"
+  section. Treating it as evidence either way would be over-reading the
+  data.
+
+## Conclusion
+
+ADR 0003's confirmation gate (1) — "`pre-` and `post-` numbers must agree
+within criterion's noise band" — is satisfied. The planner is unchanged,
+the bench numbers reflect that, and the CI gate would pass this PR cleanly.
+No flamegraph captured; no headline numbers moved, so
+`goap-planner/docs/performance.md` is left untouched.

--- a/uncharles/README.md
+++ b/uncharles/README.md
@@ -134,6 +134,33 @@ at config-load time as a `ConfigError::ActionContradiction` (the action
 would be structurally unsatisfiable). See `pendrive_audit.yaml` for a
 real-world migration of two synthetic-sensor proxies onto `forbids`.
 
+Sensors can also opt into **value capture** — `capture: stdout` stores the
+sensor command's trimmed stdout under the sensor's name. Action commands
+whose `requires` list mentions a fact with a captured value receive it as
+`UNCHARLES_FACT_<UPPER_SNAKE_CASE_NAME>=<value>` in their environment.
+Replaces sidecar-file workarounds for "carry this string to the next step"
+patterns. See [ADR 0003](../docs/adrs/0003-value-carrying-facts-runtime-side.md):
+
+```yaml
+sensors:
+  - name: target_sha
+    cmd: ["git", "rev-parse", "origin/main"]
+    capture: stdout
+
+actions:
+  - name: deploy
+    cost: 5.0
+    requires: [target_sha]
+    adds: [deployed]
+    # cmd reads $UNCHARLES_FACT_TARGET_SHA from its env
+    cmd: ["sh", "-c", 'gh workflow run deploy.yml --ref "$UNCHARLES_FACT_TARGET_SHA"']
+```
+
+The planner stays Boolean over fact presence — values do not influence
+planning. They flow runtime-side from sensors → action env vars; lifetime is
+one invocation. Removing a fact (via `Action::removes` or sensor
+`on_failure.remove`) drops its value atomically.
+
 ## Example configs
 
 Real configs covering different domains — read them as a tour of what the runtime can express:
@@ -146,7 +173,7 @@ Real configs covering different domains — read them as a tour of what the runt
 | [`merge_gate.yaml`](configs/merge_gate.yaml) | PR-merge gate with status-check sensors |
 | [`podcast.yaml`](configs/podcast.yaml) | Podcast-episode download pipeline (RSS → fetch → archive) |
 | [`repo_validate.yaml`](configs/repo_validate.yaml) | Repo-validation pipeline (fmt + clippy + test) |
-| [`smoke_loop.yaml`](configs/smoke_loop.yaml) / [`smoke_recover.yaml`](configs/smoke_recover.yaml) / [`smoke_failure.yaml`](configs/smoke_failure.yaml) | Side-effect-free smoke configs used by the integration tests |
+| [`smoke_loop.yaml`](configs/smoke_loop.yaml) / [`smoke_recover.yaml`](configs/smoke_recover.yaml) / [`smoke_failure.yaml`](configs/smoke_failure.yaml) / [`smoke_capture.yaml`](configs/smoke_capture.yaml) | Side-effect-free smoke configs used by the integration tests |
 
 ## Architecture
 

--- a/uncharles/configs/release_watch.yaml
+++ b/uncharles/configs/release_watch.yaml
@@ -36,6 +36,16 @@ sensors:
         [ -f .uncharles/state/in_flight_sha ] && exit 1
         [ "$remote" = "$last" ]
 
+  # `target_sha` — captures the current `origin/main` SHA into the runtime
+  # `Values` map (ADR 0003). `idle` above has already done `git fetch`, so
+  # this is just a local rev-parse. Downstream actions that want the SHA
+  # read `UNCHARLES_FACT_TARGET_SHA` from their environment instead of
+  # re-running `git rev-parse origin/main` themselves — fewer subshells per
+  # iteration and a single source of truth.
+  - name: target_sha
+    cmd: ["git", "rev-parse", "origin/main"]
+    capture: stdout
+
   # `new_commit_available` — origin/main differs from last_seen_sha and we
   # haven't already triggered a deploy for it. Mutually exclusive with
   # `deploy_in_flight` so the planner doesn't try to re-trigger.
@@ -70,9 +80,12 @@ sensors:
 actions:
   # Record the target SHA and dispatch the workflow. Subsequent iterations
   # see deploy_in_flight=true and the planner picks await_deploy next.
+  # `target_sha` in `requires` causes uncharles to inject
+  # `UNCHARLES_FACT_TARGET_SHA=<sha>` into the cmd's environment (ADR 0003)
+  # — replaces the previous `sha=$(git rev-parse origin/main)` subshell.
   - name: trigger_deploy
     cost: 5.0
-    requires: [new_commit_available]
+    requires: [new_commit_available, target_sha]
     adds: [deploy_in_flight]
     cmd:
       - sh
@@ -80,9 +93,8 @@ actions:
       - |
         set -e
         mkdir -p .uncharles/state
-        sha=$(git rev-parse origin/main)
-        echo "$sha" > .uncharles/state/in_flight_sha
-        gh workflow run deploy.yml --ref "$sha"
+        echo "$UNCHARLES_FACT_TARGET_SHA" > .uncharles/state/in_flight_sha
+        gh workflow run deploy.yml --ref "$UNCHARLES_FACT_TARGET_SHA"
 
   # Pacing step. The sensor decides whether `deploy_succeeded` is real;
   # the optimistic effect here is corrected by the next iteration's sensor

--- a/uncharles/configs/smoke_capture.yaml
+++ b/uncharles/configs/smoke_capture.yaml
@@ -1,0 +1,45 @@
+# Side-effect-free config used to smoke-test the value-carrying-fact
+# mechanism (ADR 0003). Sensors capture stdout into a runtime `Values` map;
+# downstream actions read the value via `UNCHARLES_FACT_<NAME>` env vars.
+#
+# Observability: actions echo the injected env var to stderr so the runtime
+# captures it in `ActionResult.stderr`, which lands in the NDJSON `executed`
+# event. Integration tests assert on that to prove the round-trip works
+# end-to-end through the compiled binary.
+
+sensors:
+  # Sets the fact `heartbeat` (default behaviour: success → add named fact).
+  - name: heartbeat
+    cmd: ["true"]
+
+  # `capture: stdout` opts this sensor into value capture. On success, the
+  # trimmed stdout (here `abc-123`) is stored under `target` in the runtime
+  # Values map.
+  - name: target
+    cmd: ["sh", "-c", "echo abc-123"]
+    capture: stdout
+
+actions:
+  # Requires `target`, so when this action's cmd is executed the runtime
+  # injects `UNCHARLES_FACT_TARGET=abc-123` into the child environment. The
+  # cmd echoes it to stderr — observable in the executed event.
+  - name: emit_value
+    cost: 1.0
+    requires: [heartbeat, target]
+    adds: [value_emitted]
+    cmd: ["sh", "-c", "echo \"$UNCHARLES_FACT_TARGET\" >&2"]
+
+  # No `requires: [target]`, so the env var is NOT injected here even though
+  # `target` has a value. Echo the lookup with a default so the test can
+  # assert the env var is unset (privacy invariant from ADR 0003).
+  - name: finalize
+    cost: 1.0
+    requires: [value_emitted]
+    adds: [finished]
+    cmd:
+      - sh
+      - -c
+      - 'printf "<%s>" "${UNCHARLES_FACT_TARGET-unset}" >&2'
+
+goal:
+  requires: [finished]

--- a/uncharles/src/config.rs
+++ b/uncharles/src/config.rs
@@ -17,6 +17,12 @@ pub struct Config {
 ///
 /// Override either side to model richer outcomes (e.g. a build sensor that
 /// adds `tests_failing` on failure rather than just removing `tests_passing`).
+///
+/// Set `capture: stdout` to opt the sensor into value capture: when the
+/// command exits successfully, its trimmed stdout is stored in the runtime
+/// `Values` map under this sensor's `name`. Action commands then receive the
+/// value as `UNCHARLES_FACT_<NAME>=<value>` whenever the action's `requires`
+/// list mentions a fact with a captured value. See ADR 0003.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SensorSpec {
@@ -26,6 +32,21 @@ pub struct SensorSpec {
     pub on_success: Option<Effects>,
     #[serde(default)]
     pub on_failure: Option<Effects>,
+    #[serde(default)]
+    pub capture: Option<Capture>,
+}
+
+/// Source of a sensor's captured value.
+///
+/// `stdout` is the only variant in v1: when the sensor command exits
+/// successfully, its stdout (trimmed of trailing whitespace) becomes the
+/// captured value. Future variants (`stderr`, structured shapes) would extend
+/// this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
+pub enum Capture {
+    /// Capture the trimmed stdout of the sensor command.
+    Stdout,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -299,6 +320,7 @@ mod tests {
             cmd: vec!["true".into()],
             on_success: None,
             on_failure: None,
+            capture: None,
         };
         let effects = spec.effects_for(true);
         assert_eq!(effects.add, vec!["ready"]);
@@ -312,6 +334,7 @@ mod tests {
             cmd: vec!["false".into()],
             on_success: None,
             on_failure: None,
+            capture: None,
         };
         let effects = spec.effects_for(false);
         assert!(effects.add.is_empty());
@@ -328,6 +351,7 @@ mod tests {
                 remove: vec!["cold".into()],
             }),
             on_failure: None,
+            capture: None,
         };
         let effects = spec.effects_for(true);
         assert_eq!(effects.add, vec!["ok", "warm"]);
@@ -421,6 +445,57 @@ mod tests {
         "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.actions[0].on_failure.is_none());
+    }
+
+    #[test]
+    fn parses_sensor_with_capture_stdout() {
+        let yaml = r#"
+            sensors:
+              - name: target_sha
+                cmd: ["git", "rev-parse", "origin/main"]
+                capture: stdout
+            actions: []
+            goal:
+              requires: [target_sha]
+        "#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.sensors[0].capture, Some(Capture::Stdout));
+    }
+
+    #[test]
+    fn sensor_capture_defaults_to_none() {
+        let yaml = r#"
+            sensors:
+              - name: ready
+                cmd: ["true"]
+            actions: []
+            goal:
+              requires: [done]
+        "#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.sensors[0].capture.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_capture_variant() {
+        // ADR 0003 commits to `stdout` as the only v1 variant. Future
+        // variants (`stderr`, structured) are reserved; mistypes must fail
+        // loudly at config-load time rather than silently disabling capture.
+        let yaml = r#"
+            sensors:
+              - name: target_sha
+                cmd: ["true"]
+                capture: bogus
+            actions: []
+            goal:
+              requires: [target_sha]
+        "#;
+        let err = serde_yaml::from_str::<Config>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bogus") || msg.contains("variant"),
+            "expected unknown-variant error, got: {msg}",
+        );
     }
 
     #[test]

--- a/uncharles/src/inspect.rs
+++ b/uncharles/src/inspect.rs
@@ -1229,6 +1229,7 @@ mod tests {
                 remove: vec![],
             }),
             on_failure: None,
+            capture: None,
         }];
         let actions = vec![ActionSpec {
             name: "act".into(),

--- a/uncharles/src/main.rs
+++ b/uncharles/src/main.rs
@@ -343,6 +343,12 @@ fn emit_outcome(outcome: &Outcome, pretty: bool) {
         for fact in &outcome.state_facts {
             println!("  {fact}");
         }
+        if !outcome.values.is_empty() {
+            println!("\n--- values ---");
+            for (k, v) in &outcome.values {
+                println!("  {k}={v}");
+            }
+        }
         println!("\n--- plan ---");
         match &outcome.plan {
             Some(plan) if plan.steps.is_empty() => {
@@ -367,8 +373,10 @@ fn emit_outcome(outcome: &Outcome, pretty: bool) {
             "success": r.success,
             "added": r.added,
             "removed": r.removed,
+            "captured_value": r.captured_value,
         })).collect::<Vec<_>>(),
         "state": outcome.state_facts,
+        "values": outcome.values,
         "plan": outcome.plan.as_ref().map(|p| serde_json::json!({
             "steps": p.steps,
             "cost": p.cost,
@@ -384,6 +392,7 @@ fn emit_event(event: &LoopEvent, pretty: bool) {
                 iteration,
                 readings,
                 state,
+                values,
             } => {
                 let ok_count = readings.iter().filter(|r| r.success).count();
                 println!(
@@ -393,6 +402,11 @@ fn emit_event(event: &LoopEvent, pretty: bool) {
                     state.len(),
                     state.join(", "),
                 );
+                if !values.is_empty() {
+                    let pairs: Vec<String> =
+                        values.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                    println!("      values   {}", pairs.join(", "),);
+                }
             }
             LoopEvent::Planned { iteration, plan } => match plan {
                 None => println!("[{iteration:>3}] plan     no plan exists"),
@@ -424,6 +438,7 @@ fn emit_event(event: &LoopEvent, pretty: bool) {
             iteration,
             readings,
             state,
+            values,
         } => serde_json::json!({
             "event": "sensed",
             "iteration": iteration,
@@ -432,8 +447,10 @@ fn emit_event(event: &LoopEvent, pretty: bool) {
                 "success": r.success,
                 "added": r.added,
                 "removed": r.removed,
+                "captured_value": r.captured_value,
             })).collect::<Vec<_>>(),
             "state": state,
+            "values": values,
         }),
         LoopEvent::Planned { iteration, plan } => serde_json::json!({
             "event": "planned",

--- a/uncharles/src/run.rs
+++ b/uncharles/src/run.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -5,7 +6,15 @@ use std::time::{Duration, Instant};
 
 use goap_planner::{Action, Goal, Planner, State};
 
-use crate::config::{ActionSpec, Config, SensorSpec};
+use crate::config::{ActionSpec, Capture, Config, SensorSpec};
+
+/// Per-cycle map of fact name → captured string value.
+///
+/// Populated by sensors that opt into [`Capture::Stdout`] and consumed by
+/// [`execute_action`] as `UNCHARLES_FACT_<NAME>` env vars on the child
+/// process. Lives alongside [`State`] but is invisible to `goap-planner`'s
+/// BFS — see ADR 0003 for the layering rationale.
+pub type Values = BTreeMap<String, String>;
 
 #[derive(Debug, Clone)]
 pub struct SensorReading {
@@ -13,6 +22,9 @@ pub struct SensorReading {
     pub success: bool,
     pub added: Vec<String>,
     pub removed: Vec<String>,
+    /// Trimmed stdout when the sensor declared `capture: stdout` and exited
+    /// successfully; `None` otherwise.
+    pub captured_value: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -60,25 +72,60 @@ impl std::fmt::Display for RunError {
 
 impl std::error::Error for RunError {}
 
-pub fn run_sensor(spec: &SensorSpec, state: &mut State) -> Result<SensorReading, RunError> {
+pub fn run_sensor(
+    spec: &SensorSpec,
+    state: &mut State,
+    values: &mut Values,
+) -> Result<SensorReading, RunError> {
     let cmd_name = spec.cmd.first().cloned().unwrap_or_default();
-    let status = Command::new(&cmd_name)
-        .args(spec.cmd.iter().skip(1))
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|e| RunError::SensorExec {
-            name: spec.name.clone(),
-            error: e.to_string(),
-        })?;
+    let mut command = Command::new(&cmd_name);
+    command.args(spec.cmd.iter().skip(1)).stderr(Stdio::null());
 
-    let success = status.success();
+    let (success, captured_value) = match spec.capture {
+        Some(Capture::Stdout) => {
+            let output =
+                command
+                    .stdout(Stdio::piped())
+                    .output()
+                    .map_err(|e| RunError::SensorExec {
+                        name: spec.name.clone(),
+                        error: e.to_string(),
+                    })?;
+            let success = output.status.success();
+            let captured = if success {
+                Some(
+                    String::from_utf8_lossy(&output.stdout)
+                        .trim_end()
+                        .to_string(),
+                )
+            } else {
+                None
+            };
+            (success, captured)
+        }
+        None => {
+            let status =
+                command
+                    .stdout(Stdio::null())
+                    .status()
+                    .map_err(|e| RunError::SensorExec {
+                        name: spec.name.clone(),
+                        error: e.to_string(),
+                    })?;
+            (status.success(), None)
+        }
+    };
+
     let effects = spec.effects_for(success);
     for fact in &effects.add {
         state.insert(fact.clone());
     }
+    if let Some(ref v) = captured_value {
+        values.insert(spec.name.clone(), v.clone());
+    }
     for fact in &effects.remove {
         state.remove(fact);
+        values.remove(fact);
     }
 
     Ok(SensorReading {
@@ -86,10 +133,11 @@ pub fn run_sensor(spec: &SensorSpec, state: &mut State) -> Result<SensorReading,
         success,
         added: effects.add,
         removed: effects.remove,
+        captured_value,
     })
 }
 
-pub fn execute_action(spec: &ActionSpec) -> Result<ActionResult, RunError> {
+pub fn execute_action(spec: &ActionSpec, values: &Values) -> Result<ActionResult, RunError> {
     let cmd = spec
         .cmd
         .as_ref()
@@ -97,15 +145,25 @@ pub fn execute_action(spec: &ActionSpec) -> Result<ActionResult, RunError> {
             name: spec.name.clone(),
         })?;
     let cmd_name = cmd.first().cloned().unwrap_or_default();
-    let output = Command::new(&cmd_name)
+    let mut command = Command::new(&cmd_name);
+    command
         .args(cmd.iter().skip(1))
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|e| RunError::ActionExec {
-            name: spec.name.clone(),
-            error: e.to_string(),
-        })?;
+        .stderr(Stdio::piped());
+
+    // Inject UNCHARLES_FACT_<NAME>=<value> for each `requires` fact that has
+    // a captured value. Facts without values produce no env var (not an
+    // empty one). See ADR 0003 for the contract.
+    for fact in &spec.requires {
+        if let Some(value) = values.get(fact) {
+            command.env(fact_env_var(fact), value);
+        }
+    }
+
+    let output = command.output().map_err(|e| RunError::ActionExec {
+        name: spec.name.clone(),
+        error: e.to_string(),
+    })?;
 
     Ok(ActionResult {
         name: spec.name.clone(),
@@ -115,6 +173,26 @@ pub fn execute_action(spec: &ActionSpec) -> Result<ActionResult, RunError> {
             .trim_end()
             .to_string(),
     })
+}
+
+/// Map a fact name to the env-var name used for value injection.
+///
+/// `target_sha` → `UNCHARLES_FACT_TARGET_SHA`. Non-ASCII-alphanumeric
+/// characters collapse to `_`. The mapping is lossy on purpose: two distinct
+/// fact names that collide here would clash in the child environment, but
+/// such names are exotic enough that the collision is acceptable
+/// (documented in ADR 0003).
+pub(crate) fn fact_env_var(fact: &str) -> String {
+    let mut s = String::with_capacity("UNCHARLES_FACT_".len() + fact.len());
+    s.push_str("UNCHARLES_FACT_");
+    for c in fact.chars() {
+        if c.is_ascii_alphanumeric() {
+            s.push(c.to_ascii_uppercase());
+        } else {
+            s.push('_');
+        }
+    }
+    s
 }
 
 /// Sleep for up to `total_ms` milliseconds, waking early if `interrupted`
@@ -185,15 +263,17 @@ pub fn build_goal(spec: &crate::config::GoalSpec) -> Goal {
 pub struct Outcome {
     pub readings: Vec<SensorReading>,
     pub state_facts: Vec<String>,
+    pub values: Values,
     pub plan: Option<goap_planner::Plan>,
 }
 
 pub fn sense_and_plan(config: &Config, seed: Vec<String>) -> Result<Outcome, RunError> {
     let mut state = State::from_facts(seed);
+    let mut values = Values::new();
 
     let mut readings = Vec::with_capacity(config.sensors.len());
     for sensor in &config.sensors {
-        readings.push(run_sensor(sensor, &mut state)?);
+        readings.push(run_sensor(sensor, &mut state, &mut values)?);
     }
 
     let actions = build_actions(&config.actions);
@@ -208,6 +288,7 @@ pub fn sense_and_plan(config: &Config, seed: Vec<String>) -> Result<Outcome, Run
     Ok(Outcome {
         readings,
         state_facts,
+        values,
         plan,
     })
 }
@@ -218,6 +299,7 @@ pub enum LoopEvent {
         iteration: usize,
         readings: Vec<SensorReading>,
         state: Vec<String>,
+        values: Values,
     },
     Planned {
         iteration: usize,
@@ -294,6 +376,7 @@ pub fn run_loop(
     mut on_event: impl FnMut(LoopEvent),
 ) -> Result<LoopOutcome, RunError> {
     let mut state = State::from_facts(seed);
+    let mut values = Values::new();
     let actions = build_actions(&config.actions);
     let goal = build_goal(&config.goal);
     let planner = Planner::new(actions);
@@ -314,7 +397,7 @@ pub fn run_loop(
 
         let mut readings = Vec::with_capacity(config.sensors.len());
         for sensor in &config.sensors {
-            readings.push(run_sensor(sensor, &mut state)?);
+            readings.push(run_sensor(sensor, &mut state, &mut values)?);
         }
         let mut state_facts: Vec<String> = state.facts().map(String::from).collect();
         state_facts.sort();
@@ -322,6 +405,7 @@ pub fn run_loop(
             iteration,
             readings,
             state: state_facts,
+            values: values.clone(),
         });
 
         let plan = planner.plan(&state, &goal).map_err(RunError::Planner)?;
@@ -338,7 +422,7 @@ pub fn run_loop(
             Some(p) => {
                 let next = &p.steps[0];
                 let spec = find_action_spec(&config.actions, next)?;
-                let result = execute_action(spec)?;
+                let result = execute_action(spec, &values)?;
                 let result_for_event = result.clone();
                 on_event(LoopEvent::Executed {
                     iteration,
@@ -359,6 +443,7 @@ pub fn run_loop(
                     // success-path contract, not the failure aftermath.
                     for fact in &failure_effects.remove {
                         state.remove(fact);
+                        values.remove(fact);
                     }
                     for fact in &failure_effects.add {
                         state.insert(fact.clone());
@@ -370,8 +455,11 @@ pub fn run_loop(
                 // next iteration plans from the expected post-state. Sensors
                 // run again at the top of the next iteration and will correct
                 // the state if reality disagrees — that's the replan trigger.
+                // Removing a fact also drops its captured value: ADR 0003
+                // commits to atomic fact-and-value lifetimes.
                 for fact in &spec.removes {
                     state.remove(fact);
+                    values.remove(fact);
                 }
                 for fact in &spec.adds {
                     state.insert(fact.clone());
@@ -393,6 +481,7 @@ mod tests {
             cmd: cmd.iter().map(|s| s.to_string()).collect(),
             on_success: None,
             on_failure: None,
+            capture: None,
         }
     }
 
@@ -416,17 +505,21 @@ mod tests {
     #[test]
     fn sensor_success_adds_fact_named_after_sensor() {
         let mut state = State::new();
-        let reading = run_sensor(&sensor("ready", &["true"]), &mut state).unwrap();
+        let mut values = Values::new();
+        let reading = run_sensor(&sensor("ready", &["true"]), &mut state, &mut values).unwrap();
         assert!(reading.success);
         assert_eq!(reading.added, vec!["ready"]);
         assert!(reading.removed.is_empty());
+        assert!(reading.captured_value.is_none());
         assert!(state.contains("ready"));
+        assert!(values.is_empty());
     }
 
     #[test]
     fn sensor_failure_removes_fact_named_after_sensor() {
         let mut state = State::from_facts(["ready"]);
-        let reading = run_sensor(&sensor("ready", &["false"]), &mut state).unwrap();
+        let mut values = Values::new();
+        let reading = run_sensor(&sensor("ready", &["false"]), &mut state, &mut values).unwrap();
         assert!(!reading.success);
         assert_eq!(reading.removed, vec!["ready"]);
         assert!(reading.added.is_empty());
@@ -436,6 +529,7 @@ mod tests {
     #[test]
     fn sensor_custom_on_success_overrides_default() {
         let mut state = State::new();
+        let mut values = Values::new();
         let spec = SensorSpec {
             name: "build".into(),
             cmd: vec!["true".into()],
@@ -444,9 +538,10 @@ mod tests {
                 remove: vec!["build_failing".into()],
             }),
             on_failure: None,
+            capture: None,
         };
         let mut state_with_failing = State::from_facts(["build_failing"]);
-        let reading = run_sensor(&spec, &mut state_with_failing).unwrap();
+        let reading = run_sensor(&spec, &mut state_with_failing, &mut values).unwrap();
         assert!(reading.success);
         assert!(state_with_failing.contains("build_ok"));
         assert!(state_with_failing.contains("tests_pass"));
@@ -459,20 +554,93 @@ mod tests {
             cmd: vec!["true".into()],
             on_success: Some(Effects::default()),
             on_failure: None,
+            capture: None,
         };
-        run_sensor(&suppress, &mut state).unwrap();
+        run_sensor(&suppress, &mut state, &mut values).unwrap();
         assert!(!state.contains("noisy"));
     }
 
     #[test]
     fn sensor_missing_command_returns_sensor_exec_error() {
         let mut state = State::new();
+        let mut values = Values::new();
         let err = run_sensor(
             &sensor("ghost", &["definitely-not-a-real-binary-xyz123"]),
             &mut state,
+            &mut values,
         )
         .unwrap_err();
         assert!(matches!(err, RunError::SensorExec { ref name, .. } if name == "ghost"));
+    }
+
+    // ---------------------------------------------------------------------
+    // run_sensor — capture: stdout (ADR 0003)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn sensor_with_capture_stdout_stores_trimmed_value_on_success() {
+        let mut state = State::new();
+        let mut values = Values::new();
+        let spec = SensorSpec {
+            name: "target_sha".into(),
+            cmd: vec!["sh".into(), "-c".into(), "printf 'abc123\\n'".into()],
+            on_success: None,
+            on_failure: None,
+            capture: Some(Capture::Stdout),
+        };
+        let reading = run_sensor(&spec, &mut state, &mut values).unwrap();
+        assert!(reading.success);
+        assert_eq!(reading.captured_value.as_deref(), Some("abc123"));
+        assert_eq!(values.get("target_sha").map(String::as_str), Some("abc123"));
+        assert!(state.contains("target_sha"));
+    }
+
+    #[test]
+    fn sensor_with_capture_stdout_does_not_store_value_on_failure() {
+        let mut state = State::from_facts(["target_sha"]);
+        let mut values = Values::new();
+        values.insert("target_sha".into(), "stale".into());
+        let spec = SensorSpec {
+            name: "target_sha".into(),
+            cmd: vec!["false".into()],
+            on_success: None,
+            on_failure: None,
+            capture: Some(Capture::Stdout),
+        };
+        let reading = run_sensor(&spec, &mut state, &mut values).unwrap();
+        assert!(!reading.success);
+        assert!(reading.captured_value.is_none());
+        // Default on_failure removes the named fact, which atomically drops
+        // its value too — ADR 0003's atomic-remove rule.
+        assert!(!state.contains("target_sha"));
+        assert!(!values.contains_key("target_sha"));
+    }
+
+    #[test]
+    fn sensor_without_capture_does_not_populate_values() {
+        let mut state = State::new();
+        let mut values = Values::new();
+        let spec = sensor("ready", &["sh", "-c", "echo would-have-been-captured"]);
+        let reading = run_sensor(&spec, &mut state, &mut values).unwrap();
+        assert!(reading.success);
+        assert!(reading.captured_value.is_none());
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn sensor_capture_overwrites_prior_value() {
+        let mut state = State::new();
+        let mut values = Values::new();
+        values.insert("target_sha".into(), "old".into());
+        let spec = SensorSpec {
+            name: "target_sha".into(),
+            cmd: vec!["sh".into(), "-c".into(), "echo new".into()],
+            on_success: None,
+            on_failure: None,
+            capture: Some(Capture::Stdout),
+        };
+        run_sensor(&spec, &mut state, &mut values).unwrap();
+        assert_eq!(values.get("target_sha").map(String::as_str), Some("new"));
     }
 
     // ---------------------------------------------------------------------
@@ -481,7 +649,8 @@ mod tests {
 
     #[test]
     fn execute_action_success_returns_zero_exit() {
-        let result = execute_action(&action("noop", &["true"], &[], &[])).unwrap();
+        let values = Values::new();
+        let result = execute_action(&action("noop", &["true"], &[], &[]), &values).unwrap();
         assert!(result.success);
         assert_eq!(result.exit_code, Some(0));
         assert!(result.stderr.is_empty());
@@ -490,10 +659,83 @@ mod tests {
     #[test]
     fn execute_action_failure_captures_exit_and_stderr() {
         let spec = action("failing", &["sh", "-c", "echo boom >&2; exit 7"], &[], &[]);
-        let result = execute_action(&spec).unwrap();
+        let values = Values::new();
+        let result = execute_action(&spec, &values).unwrap();
         assert!(!result.success);
         assert_eq!(result.exit_code, Some(7));
         assert_eq!(result.stderr, "boom");
+    }
+
+    #[test]
+    fn execute_action_injects_uncharles_fact_env_for_required_facts() {
+        // Action with `requires: [target_sha]`. The cmd reads the env var
+        // and prints it to stderr (which `execute_action` captures), so
+        // the round-trip is observable via ActionResult.stderr.
+        let spec = action(
+            "deploy",
+            &["sh", "-c", "echo $UNCHARLES_FACT_TARGET_SHA >&2"],
+            &["target_sha"],
+            &[],
+        );
+        let mut values = Values::new();
+        values.insert("target_sha".into(), "abc123".into());
+        let result = execute_action(&spec, &values).unwrap();
+        assert!(
+            result.success,
+            "exit={:?} stderr={:?}",
+            result.exit_code, result.stderr
+        );
+        assert_eq!(result.stderr, "abc123");
+    }
+
+    #[test]
+    fn execute_action_does_not_inject_env_for_facts_without_values() {
+        // `requires` mentions `available`, but no value exists for it.
+        // The env var must be unset (printf prints empty).
+        let spec = action(
+            "noop",
+            &[
+                "sh",
+                "-c",
+                "printf '<%s>' \"${UNCHARLES_FACT_AVAILABLE-unset}\" >&2",
+            ],
+            &["available"],
+            &[],
+        );
+        let values = Values::new();
+        let result = execute_action(&spec, &values).unwrap();
+        assert!(result.success);
+        assert_eq!(result.stderr, "<unset>");
+    }
+
+    #[test]
+    fn execute_action_does_not_inject_env_for_non_required_facts() {
+        // Value exists for `target_sha` but the action does not require
+        // it. Env var must NOT be set (privacy: an action cannot peek at
+        // values it didn't declare a dependency on).
+        let spec = action(
+            "noop",
+            &[
+                "sh",
+                "-c",
+                "printf '<%s>' \"${UNCHARLES_FACT_TARGET_SHA-unset}\" >&2",
+            ],
+            &[],
+            &[],
+        );
+        let mut values = Values::new();
+        values.insert("target_sha".into(), "abc123".into());
+        let result = execute_action(&spec, &values).unwrap();
+        assert!(result.success);
+        assert_eq!(result.stderr, "<unset>");
+    }
+
+    #[test]
+    fn fact_env_var_uppercases_and_replaces_non_alphanumeric() {
+        assert_eq!(fact_env_var("target_sha"), "UNCHARLES_FACT_TARGET_SHA");
+        assert_eq!(fact_env_var("plan_clean"), "UNCHARLES_FACT_PLAN_CLEAN");
+        assert_eq!(fact_env_var("a-b.c"), "UNCHARLES_FACT_A_B_C");
+        assert_eq!(fact_env_var("simple"), "UNCHARLES_FACT_SIMPLE");
     }
 
     #[test]
@@ -508,14 +750,16 @@ mod tests {
             cmd: None,
             on_failure: None,
         };
-        let err = execute_action(&spec).unwrap_err();
+        let values = Values::new();
+        let err = execute_action(&spec, &values).unwrap_err();
         assert!(matches!(err, RunError::ActionMissingCmd { ref name } if name == "no_cmd"));
     }
 
     #[test]
     fn execute_action_unknown_binary_returns_action_exec_error() {
         let spec = action("ghost", &["definitely-not-a-real-binary-xyz123"], &[], &[]);
-        let err = execute_action(&spec).unwrap_err();
+        let values = Values::new();
+        let err = execute_action(&spec, &values).unwrap_err();
         assert!(matches!(err, RunError::ActionExec { ref name, .. } if name == "ghost"));
     }
 

--- a/uncharles/tests/cli.rs
+++ b/uncharles/tests/cli.rs
@@ -181,6 +181,7 @@ fn release_watch_dry_run_emits_expected_schema() {
         sensor_names,
         vec![
             "idle",
+            "target_sha",
             "new_commit_available",
             "deploy_in_flight",
             "deploy_succeeded",
@@ -365,6 +366,69 @@ fn tofu_drift_watch_dry_run_pins_post_apply_watcher_design() {
             );
         }
     }
+}
+
+#[test]
+fn execute_loop_captures_sensor_stdout_and_injects_into_action_env() {
+    // ADR 0003 round-trip: sensor `target` captures stdout into the runtime
+    // values map; `emit_value` requires `target` and reads
+    // UNCHARLES_FACT_TARGET to stderr (which lands in the executed event);
+    // `finalize` does NOT require `target` so its env var is unset (privacy
+    // invariant: actions only see values for facts they declared).
+    let output = Command::new(binary())
+        .arg("run")
+        .arg("--config")
+        .arg(config_path("smoke_capture.yaml"))
+        .arg("--execute")
+        .output()
+        .expect("failed to spawn uncharles");
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let events: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    // Final outcome is goal-satisfied.
+    let last = events.last().unwrap();
+    assert_eq!(last["outcome"], "goal_satisfied");
+
+    // `target` sensor reports its captured value on every iteration. Use
+    // the first sensed event for assertion stability.
+    let first_sensed = events
+        .iter()
+        .find(|e| e["event"] == "sensed")
+        .expect("expected a sensed event");
+    let target_reading = first_sensed["readings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["name"] == "target")
+        .expect("target sensor reading missing");
+    assert_eq!(target_reading["captured_value"], "abc-123");
+    assert_eq!(target_reading["success"], true);
+    assert_eq!(first_sensed["values"]["target"], "abc-123");
+
+    // emit_value's stderr proves UNCHARLES_FACT_TARGET was injected.
+    let emit_executed = events
+        .iter()
+        .find(|e| e["event"] == "executed" && e["result"]["name"] == "emit_value")
+        .expect("emit_value executed event missing");
+    assert_eq!(emit_executed["result"]["success"], true);
+    assert_eq!(emit_executed["result"]["stderr"], "abc-123");
+
+    // finalize does NOT require `target`, so env var must be unset.
+    let final_executed = events
+        .iter()
+        .find(|e| e["event"] == "executed" && e["result"]["name"] == "finalize")
+        .expect("finalize executed event missing");
+    assert_eq!(final_executed["result"]["stderr"], "<unset>");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Closes #18 by adopting the runtime-side shape of the recommendation rather than the literal "extend `State`" wording — values flow entirely through `uncharles` (sensor stdout capture → per-cycle `Values` map → `UNCHARLES_FACT_<NAME>` env vars on action commands). The planner stays Boolean. The layering choice and its consequences are captured in [ADR 0003](docs/adrs/0003-value-carrying-facts-runtime-side.md).
- New YAML field on `SensorSpec`: `capture: stdout` (the only v1 variant — `stderr` and structured forms are reserved). Existing configs are bit-for-bit compatible.
- Bench evidence: [`goap-planner/docs/perf-comparison-2026-05-03.md`](goap-planner/docs/perf-comparison-2026-05-03.md). Source under `goap-planner/src/` is byte-identical between the pre and post runs; all bench drift is within the same-machine noise band (largest +5.0% at `concurrent_plans/sequential_64`, well below the CI 10% gate).

## Conventional commit

Type (check one):

- [x] `feat` — new user-visible capability

Scope (crate or area):

`uncharles`

## Breaking changes

None. Existing configs parse unchanged; the `capture` field is optional. Public types `SensorReading`, `Outcome`, `LoopEvent::Sensed` gain new fields (additive); since `uncharles` is a binary crate (not published), this is not a semver concern.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — 78 unit tests in uncharles (was 75: 3 new for capture lifecycle, env injection, fact_env_var mapping), 13 CLI integration tests (was 12: 1 new end-to-end through the compiled binary), plus YAML parse tests for `capture: stdout` and unknown-variant rejection.
- [x] Manual verification:
  - `cargo run -q -p uncharles -- inspect --config uncharles/configs/smoke_capture.yaml` — clean static analysis.
  - `cargo run -q -p uncharles -- run --config uncharles/configs/smoke_capture.yaml --execute` — observed `UNCHARLES_FACT_TARGET=abc-123` injected into `emit_value`'s env (echoed to stderr in the executed event); `finalize` (which doesn't `requires: [target]`) sees the env unset.
  - `cargo run -q -p uncharles -- inspect --config uncharles/configs/release_watch.yaml` — clean after migrating `trigger_deploy` to read `$UNCHARLES_FACT_TARGET_SHA` instead of running `git rev-parse origin/main` in its own subshell.
- [x] Benchmarks: `cargo bench -p goap-planner --bench performance -- --save-baseline pre-issue-18` then `--baseline pre-issue-18`. Comparison written to [`goap-planner/docs/perf-comparison-2026-05-03.md`](goap-planner/docs/perf-comparison-2026-05-03.md), raw log archived as [`goap-planner/docs/bench-2026-05-03-issue-18.txt`](goap-planner/docs/bench-2026-05-03-issue-18.txt).

## Linked issues

Closes #18.

Refs ADR 0002 — gap 2 (three-valued plan exit code as first-class facts) becomes a one-line retire of `tofu_drift_watch.yaml`'s wrapper-script trick in a follow-up: replace the three Boolean `plan_*` sensors plus the `last_plan_exit` marker file with one `plan_result` sensor that captures stdout. Out of scope for this PR.