### PR TITLE
feat(ci): add nixpkgs derivation mirror and PR-time build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace --all-features --release
+
+  # Builds the in-repo mirror of the nixpkgs derivation (per ADR 0004) against
+  # the current workspace source, so derivation breakage is caught at PR time
+  # rather than when a nixpkgs PR is opened.
+  nix-build:
+    name: nix-build (uncharles)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix-build nix/ci.nix --no-out-link

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,0 +1,18 @@
+# Local / CI entry point for building the `uncharles` Nix derivation.
+#
+# `nix-build nix/ci.nix` builds `package.nix` against the current workspace
+# (overriding the release-tag default for `src` and the co-located default
+# for `cargoLockFile`). Used by `.github/workflows/ci.yml` on every PR and
+# by developers iterating on the derivation locally.
+#
+# Nixpkgs is taken from the channel the GitHub Action sets up
+# (`nixos-unstable` in `ci.yml`); for local invocations without a configured
+# channel, `<nixpkgs>` falls back to whatever the user's `nix-channel`
+# points at.
+
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.callPackage ./package.nix {
+  src = pkgs.lib.cleanSource ../.;
+  cargoLockFile = ../Cargo.lock;
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,60 @@
+# Nix derivation for the `uncharles` CLI.
+#
+# Per ADR 0004 (docs/adrs/0004-publish-uncharles-to-nixpkgs.md), this file is
+# the in-repo mirror of the derivation that ships in nixpkgs at
+# `pkgs/by-name/un/uncharles/package.nix`. It is built on every PR by
+# `ci.yml`'s `nix-build` job, against the current workspace source, to catch
+# derivation breakage before it reaches the nixpkgs PR queue.
+#
+# Two parameters exist so the file's *default shape* matches what nixpkgs
+# expects, while `nix/ci.nix` can override them to build the local checkout:
+#
+#   * `src` — defaults to `fetchFromGitHub` pinned to a release tag.
+#   * `cargoLockFile` — defaults to a `./Cargo.lock` co-located with this
+#     file, matching the nixpkgs convention of copying the upstream lockfile
+#     next to `package.nix`. This default file does not exist in this repo
+#     (the workspace lockfile lives at `../Cargo.lock`); `nix/ci.nix`
+#     overrides this parameter so `nix-build nix/ci.nix` works without a
+#     copy. A direct `nix-build nix/package.nix` would fail until a lockfile
+#     is co-located — which is exactly what happens when this file is copied
+#     into nixpkgs.
+#
+# When submitting (or updating) the nixpkgs derivation, copy this file to
+# `pkgs/by-name/un/uncharles/package.nix`, copy the workspace's `Cargo.lock`
+# next to it, drop the `src` parameter so the default `fetchFromGitHub`
+# applies, and replace `lib.fakeHash` with the real source hash
+# (`nix-prefetch-github` against the release tag).
+
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  src ? fetchFromGitHub {
+    owner = "leopepe";
+    repo = "automata-atelier";
+    rev = "uncharles-v${version}";
+    hash = lib.fakeHash;
+  },
+  version ? "0.1.0",
+  cargoLockFile ? ./Cargo.lock,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "uncharles";
+  inherit src version;
+
+  cargoLock.lockFile = cargoLockFile;
+
+  cargoBuildFlags = [ "-p" "uncharles" ];
+  cargoTestFlags = [ "-p" "uncharles" ];
+
+  meta = {
+    description = "Sense → plan → act runtime that drives goap-planner from a YAML config to automate shell tasks";
+    homepage = "https://github.com/leopepe/automata-atelier";
+    license = lib.licenses.mit;
+    mainProgram = "uncharles";
+    platforms = lib.platforms.unix;
+    # `maintainers` is populated when the nixpkgs PR lands; the maintainer
+    # entry has to exist in `maintainers/maintainer-list.nix` first.
+  };
+}


### PR DESCRIPTION
## Summary

Implements the first half of [ADR 0004](./docs/adrs/0004-publish-uncharles-to-nixpkgs.md) (publish \`uncharles\` to nixpkgs):

- **\`nix/package.nix\`** — the nixpkgs-shaped \`uncharles\` derivation (\`rustPlatform.buildRustPackage\`, \`cargoLock.lockFile\`, \`fetchFromGitHub\` default for \`src\`). Parameterised on \`src\` and \`cargoLockFile\` so the local/CI build can override both without diverging from the shape that gets copied upstream.
- **\`nix/ci.nix\`** — thin wrapper that calls \`package.nix\` against the current workspace source and the workspace \`Cargo.lock\`. What CI invokes and what developers can run locally with \`nix-build nix/ci.nix\`.
- **\`.github/workflows/ci.yml\`** — new \`nix-build\` job that runs on every PR using \`nixos-unstable\` from \`cachix/install-nix-action\`. Catches derivation breakage before it reaches the nixpkgs PR queue (ADR 0004 confirmation gate #1).

## Conventional commit

Type: \`feat\`

Scope: \`ci\`

## Breaking changes

None.

## Test plan

- [ ] \`cargo fmt --all\` — no changes (no Rust touched)
- [ ] \`cargo clippy --all-targets --all-features -- -D warnings\` — no changes
- [ ] \`cargo test --workspace\` — no changes
- [ ] **\`nix-build nix/ci.nix\` on this PR's CI run succeeds** — the actual gate this PR adds
- [ ] Manual verification: \`nix-build nix/ci.nix\` locally (requires Nix)

## What's next

Follow-up PRs from ADR 0004 (not in this PR):

1. \`release.yml\` extension — tag + GitHub Release after \`cargo publish -p uncharles\`
2. First nixpkgs PR against \`nixos/nixpkgs\` (manual)
3. \`uncharles/README.md\` install section once the nixpkgs PR merges

## Linked issues

Refs ADR 0004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)