### PR TITLE
fix(workspace): finish grafo-dag rename and bench --manifest-path switch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,6 +53,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `crate` is the workspace member's *directory name* — used for the
+        # baseline-availability check (`<crate>/benches/performance.rs`),
+        # the `--manifest-path <crate>/Cargo.toml` cargo invocations below,
+        # and the cache + artifact keys. It does not have to match the
+        # crate's `[package].name` in Cargo.toml; the `grafo` directory
+        # publishes as `grafo-dag` on crates.io while keeping its
+        # directory name and in-source crate name. Using manifest-path
+        # rather than `cargo bench -p <name>` keeps this gate stable
+        # across publishing-name changes.
         crate: [grafo, goap-planner]
     steps:
       - name: Checkout PR head
@@ -114,7 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           git checkout "${{ steps.base-sha.outputs.sha }}"
-          cargo bench -p ${{ matrix.crate }} --bench performance -- \
+          cargo bench --manifest-path ${{ matrix.crate }}/Cargo.toml --bench performance -- \
             --save-baseline pr-base $CRITERION_CI_FLAGS 2>&1 | tee bench-base.txt
 
       - name: Compare PR head against baseline
@@ -131,7 +140,7 @@ jobs:
         run: |
           set -euo pipefail
           git checkout "${{ github.sha }}"
-          cargo bench -p ${{ matrix.crate }} --bench performance -- \
+          cargo bench --manifest-path ${{ matrix.crate }}/Cargo.toml --bench performance -- \
             --baseline-lenient pr-base $CRITERION_CI_FLAGS 2>&1 | tee bench-head.txt
 
       - name: Run PR head benches (introductory, no baseline)
@@ -142,7 +151,7 @@ jobs:
         if: steps.baseline-check.outputs.available == 'false'
         run: |
           set -euo pipefail
-          cargo bench -p ${{ matrix.crate }} --bench performance -- \
+          cargo bench --manifest-path ${{ matrix.crate }}/Cargo.toml --bench performance -- \
             $CRITERION_CI_FLAGS 2>&1 | tee bench-head.txt
 
       - name: Detect regressions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,15 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atelier-grafo"
-version = "0.1.0"
-dependencies = [
- "criterion",
- "rayon",
- "rustc-hash",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,11 +315,20 @@ dependencies = [
 name = "goap-planner"
 version = "0.1.0"
 dependencies = [
- "atelier-grafo",
  "criterion",
+ "grafo-dag",
  "rayon",
  "rustc-hash",
  "serde_json",
+]
+
+[[package]]
+name = "grafo-dag"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "rayon",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/goap-planner/Cargo.toml
+++ b/goap-planner/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["goap", "planning", "ai", "agent", "automation"]
 categories = ["algorithms", "game-development"]
 
 [dependencies]
-grafo = { package = "atelier-grafo", path = "../grafo", version = "0.1" }
+grafo = { package = "grafo-dag", path = "../grafo", version = "0.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/grafo/Cargo.toml
+++ b/grafo/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 # `grafo` is taken on crates.io by an unrelated GPU rendering library, so
-# this crate publishes as `atelier-grafo`. Consumers in this workspace
-# (goap-planner) alias it back to `grafo` via the `package =` field so
-# source code keeps reading `use grafo::...`.
-name = "atelier-grafo"
+# this crate publishes as `grafo-dag`. `[lib] name = "grafo"` keeps the
+# in-source crate name unchanged; consumers in this workspace alias it
+# back to `grafo` via the `package =` field so source code keeps reading
+# `use grafo::...`.
+name = "grafo-dag"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
## Summary

PR #50's squash-merge only carried its first commit (the \`atelier-grafo\` rename), leaving main on a stale state. This PR applies the two changes that were on #50's branch but didn't reach main:

- **\`grafo\` publishes as \`grafo-dag\`** — the name you selected after rejecting the \`atelier-\` prefix. \`grafo/Cargo.toml\` switches \`[package].name\` and updates the leading comment.
- **\`goap-planner\` consumer alias** updated to \`grafo = { package = \"grafo-dag\", path = \"../grafo\", version = \"0.1\" }\`. Source code (\`use grafo::...\`) remains unchanged thanks to the \`[lib] name = \"grafo\"\` override + \`package =\` alias.
- **\`bench.yml\`** switches from \`cargo bench -p <name>\` to \`cargo bench --manifest-path <dir>/Cargo.toml\`. Treats the matrix value as a directory name so the bench gate stays stable across publishing-name renames — caught originally by the \`atelier-grafo\` PR breaking the \`grafo\` bench job, and still latent on main today since the fix didn't land with #50.

## Conventional commit

Type: \`fix\`

Scope: \`workspace\`

## Breaking changes

None. The crates.io publishing name for the grafo crate changes from a never-published placeholder to \`grafo-dag\`; nothing has been published, so no downstream is broken. Source code is unaffected.

## Test plan

- [x] \`cargo build --workspace\` ✓
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` ✓
- [x] \`cargo test --workspace\` ✓ (17 doctests)
- [x] \`cargo publish -p grafo-dag --dry-run --allow-dirty\` ✓
- [ ] CI \`bench (grafo)\` job passes — the latent bench fragility this fix addresses

## Linked issues

Refs ADR 0004. Follows up #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)