### PR TITLE
fix(ci): publish workspace crates in one cargo invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,11 @@
 # name stays `grafo` via `[lib].name`.
 #
 # Crates publish in dependency order: grafo-dag → goap-planner → uncharles.
-# Each downstream dry-run will fail until the upstream crate exists on
-# crates.io for real, since cargo resolves the version from the registry once
-# `version` is set on the path dep. That's expected on the first release.
+# All three are published in a single `cargo publish` invocation; cargo 1.91+
+# resolves intra-workspace path deps through a temporary local registry
+# during dry-run (so downstream dry-runs work even before grafo-dag exists
+# on crates.io) and waits for crates.io indexing between steps on a real
+# publish.
 #
 # For the first nixpkgs submission, this workflow only produces the tag and
 # Release. The nixpkgs PR itself is opened by hand against `nixos/nixpkgs`
@@ -62,31 +64,20 @@ jobs:
             exit 1
           fi
 
-      - name: Publish grafo-dag
+      - name: Publish workspace crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          # `-p` matches the [package].name. The grafo crate publishes as
-          # `grafo-dag` on crates.io (the bare `grafo` name is owned by an
-          # unrelated GPU library); the `[lib].name = "grafo"` keeps the
-          # in-source crate name unchanged for consumers.
-          flags="-p grafo-dag"
-          if [ "${{ inputs.dry-run }}" = "true" ]; then flags="$flags --dry-run"; fi
-          cargo publish $flags
-
-      - name: Publish goap-planner
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          flags="-p goap-planner"
-          if [ "${{ inputs.dry-run }}" = "true" ]; then flags="$flags --dry-run"; fi
-          cargo publish $flags
-
-      - name: Publish uncharles
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          flags="-p uncharles"
+          # One invocation publishes all three crates. cargo orders them
+          # automatically (grafo-dag → goap-planner → uncharles) by walking
+          # the path-dep graph; on dry-run it resolves the intra-workspace
+          # deps via a temporary local registry, so the downstream packages
+          # validate even when grafo-dag is not yet on crates.io. `-p`
+          # matches `[package].name`: the grafo crate publishes as
+          # `grafo-dag` (the bare `grafo` name is owned by an unrelated
+          # GPU library), with `[lib].name = "grafo"` preserving the
+          # in-source crate name for consumers.
+          flags="-p grafo-dag -p goap-planner -p uncharles"
           if [ "${{ inputs.dry-run }}" = "true" ]; then flags="$flags --dry-run"; fi
           cargo publish $flags
 

--- a/goap-planner/Cargo.toml
+++ b/goap-planner/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "Goal-Oriented Action Planning over a state-space graph. The first planner in the Automata Atelier workspace."
 keywords = ["goap", "planning", "ai", "agent", "automation"]
 categories = ["algorithms", "game-development"]
+repository = "https://github.com/leopepe/automata-atelier"
+homepage = "https://github.com/leopepe/automata-atelier"
+readme = "README.md"
 
 [dependencies]
 grafo = { package = "grafo-dag", path = "../grafo", version = "0.1" }

--- a/grafo/Cargo.toml
+++ b/grafo/Cargo.toml
@@ -11,6 +11,9 @@ license = "MIT"
 description = "Fast directed-acyclic-graph library with Dijkstra search and attribute-based path filtering. The graph kernel of the Automata Atelier workspace."
 keywords = ["graph", "dag", "dijkstra", "shortest-path", "csr"]
 categories = ["algorithms", "data-structures"]
+repository = "https://github.com/leopepe/automata-atelier"
+homepage = "https://github.com/leopepe/automata-atelier"
+readme = "README.md"
 
 [lib]
 name = "grafo"

--- a/uncharles/Cargo.toml
+++ b/uncharles/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "Sense → plan → act runtime that drives goap-planner from a YAML config to automate shell tasks. The first automaton built in the Automata Atelier workspace."
 keywords = ["goap", "planning", "automation", "agent", "cli"]
 categories = ["command-line-utilities"]
+repository = "https://github.com/leopepe/automata-atelier"
+homepage = "https://github.com/leopepe/automata-atelier"
+readme = "README.md"
 
 [dependencies]
 goap-planner = { path = "../goap-planner", version = "0.1" }


### PR DESCRIPTION
## Summary

Follow-up to #54. That PR was merged before the workspace-publish commit (`8c48a72`) landed on the branch — only the `-p grafo-dag` rename hit `main`, so the next dry-run [run 25993177721](https://github.com/leopepe/automata-atelier/actions/runs/25993177721) still failed at the `Publish goap-planner` step with the documented `no matching package named grafo-dag` error.

This PR re-applies the missing piece:

- Replace the three separate `cargo publish` steps with a single workspace-aware invocation: `cargo publish -p grafo-dag -p goap-planner -p uncharles`. Cargo 1.91+ orders them by the path-dep graph and resolves intra-workspace deps through a temporary local registry on dry-run, so downstream packages validate even when `grafo-dag` is not yet on crates.io. On a real publish, cargo waits for crates.io indexing between steps.
- Fill in `repository`, `homepage`, and `readme` on each crate's `Cargo.toml`. Removes the `manifest has no documentation, homepage or repository` warning cargo was emitting, and gives nixpkgs reviewers the metadata they expect for `meta.homepage`.

**Local verification on cargo 1.95** — `cargo publish --dry-run -p grafo-dag -p goap-planner -p uncharles` packages → verifies → dry-run-uploads all three with exit 0 and zero warnings.

## Conventional commit

Type (check one):

- [ ] `feat`
- [x] `fix`
- [ ] `docs`
- [ ] `style`
- [ ] `refactor`
- [ ] `perf`
- [ ] `test`
- [ ] `build`
- [ ] `ci`
- [ ] `chore`
- [ ] `revert`

Scope: `ci`

## Breaking changes

None.

## Test plan

- [x] `cargo fmt --all` (pre-commit hook passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (pre-commit hook passed)
- [ ] `cargo test --workspace` (workflow + manifest metadata only)
- [x] Local end-to-end dry-run: `cargo publish --dry-run -p grafo-dag -p goap-planner -p uncharles` exits 0 with zero warnings.
- [ ] Re-run `Release` workflow with `dry-run=true` after merge; expect the `Publish workspace crates` step to package + verify + dry-run-upload all three crates and the run to succeed.

## Linked issues

Refs #52, Refs #54.