### PR TITLE
feat(uncharles)!: actor reactive runtime (ADR 0005)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "uncharles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "goap-planner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,25 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -105,12 +96,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -253,27 +238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
+name = "downcast-rs"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys",
-]
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
+name = "dyn-clone"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
-]
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -288,10 +262,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -305,8 +348,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -415,6 +463,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kameo"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dfd134d7a2c6ec05ee696dcbf3f7a034bdb97ecc623e981014652dcd124d77"
+dependencies = [
+ "downcast-rs",
+ "dyn-clone",
+ "futures",
+ "kameo_macros",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "kameo_macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c9002c9ecd16e1636f566c0bf62db48e70d86ed0d0a91b398955e883217a23"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,15 +502,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "nix"
-version = "0.31.2"
+name = "mio"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
  "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -446,21 +520,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -665,6 +724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,15 +767,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "tracing",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "uncharles"
 version = "0.1.0"
 dependencies = [
  "clap",
- "ctrlc",
  "goap-planner",
+ "kameo",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tokio",
 ]
 
 [[package]]
@@ -736,6 +864,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/docs/adrs/0005-actor-based-reactive-runtime.md
+++ b/docs/adrs/0005-actor-based-reactive-runtime.md
@@ -121,12 +121,25 @@ The runtime contract this establishes:
   planning inside `goap-planner`.
 * **A root `AgentSupervisor`** links all of the above, applies the supervision
   strategy (restart a crashed sensor; escalate a crashed world-state), and
-  translates `tokio::signal::ctrl_c` into a graceful drain.
+  translates stop signals into a graceful drain.
+* **uncharles is a daemon: the run loop is perpetual by default.** Under
+  `--execute` the automaton senses continuously, plans and acts toward the goal
+  when the world diverges, and on reaching the goal **returns to sensing** — it
+  does not exit. Goal-satisfied and no-plan are non-terminal; only an
+  unrecoverable action failure, the action-cap, or a stop signal end the
+  process. As a service it drains on **SIGTERM** (systemd/Docker `stop`) as well
+  as SIGINT, and a signal-driven shutdown exits 0 (a clean stop, not an error).
+  `--once` opts into a one-shot drive-to-goal-and-exit run for CI/scripting,
+  where goal-satisfied exits 0 and an unreachable goal exits 1. This replaces
+  the previous external `run.sh` `while true; sleep` polling wrapper — the loop
+  now lives inside the automaton, which is where the maintainer placed it as the
+  core concept of the agent.
 
-Scope: this ADR covers the concurrency foundation and the reactive-sensing
-behaviour. Plugins (IPC wire protocol), concurrent multi-goal arbitration
-policy, and config hot-reload are explicitly **out of scope** here — the
-topology is designed to absorb them, but each gets its own ADR when built.
+Scope: this ADR covers the concurrency foundation, the perpetual reactive-sensing
+behaviour, and the service lifecycle (perpetual default, `--once`, SIGINT/SIGTERM
+drain). Plugins (IPC wire protocol), concurrent multi-goal arbitration policy,
+and config hot-reload are explicitly **out of scope** here — the topology is
+designed to absorb them, but each gets its own ADR when built.
 
 ### Consequences
 
@@ -222,11 +235,10 @@ The 2026-06-12 front-runner, reversed here.
 
 ## More Information
 
-* **Driving issues**: #17 (`--watch` mode for long-lived configs) and #19
-  (sensor ordering as a foot-gun) are both subsumed by the reactive runtime.
-  A dedicated `type:design` tracking issue for the broader actor pivot
-  (plugins / multi-goal / hot-reload) should be opened to host the follow-up
-  ADRs.
+* **Driving issues**: #17 (long-lived watcher mode) and #19 (sensor ordering as
+  a foot-gun) are both subsumed by the reactive runtime — watcher behaviour is
+  now the *default* (perpetual daemon), not an opt-in flag. The actor-pivot
+  tracking issue is #58.
 * **Composes with ADR 0003**: the runtime `Values` map keeps living in
   `uncharles`, now owned by `WorldStateActor` and travelling beside `State`
   through `ApplyReading`/snapshot messages. No change to ADR 0003's contract.

--- a/docs/adrs/0005-actor-based-reactive-runtime.md
+++ b/docs/adrs/0005-actor-based-reactive-runtime.md
@@ -1,0 +1,241 @@
+---
+status: proposed
+date: 2026-06-18
+decision-makers: ["@leopepe"]
+consulted: []
+informed: []
+---
+
+# Actor-based reactive runtime for uncharles (kameo)
+
+## Context and Problem Statement
+
+`uncharles`'s execute path is a single synchronous loop (`run.rs:run_loop`):
+it runs every sensor in sequence, plans once, executes one action, applies
+optimistic effects, sleeps, and repeats. The loop is structurally serial
+(sensors cannot observe concurrently) and goal-singular (one `Goal`, one
+planner). The committed roadmap — external plugins over IPC, multiple
+concurrent goals with arbitration, hot-reload of YAML at runtime — pushes in
+exactly one direction: many independent components with their own lifecycles
+exchanging messages. The immediate forcing requirement is **reactive
+sensing**: sensors run continuously and in parallel, world-state changes
+trigger replanning, and the executor runs the freshest available plan. This
+ADR settles **what concurrency foundation uncharles adopts** to get there.
+Refs #17 (watcher mode), refs #19 (sensor ordering as a foot-gun).
+
+## Decision Drivers
+
+* **Reactive, parallel sensing.** Sensors must run concurrently (real OS-thread
+  parallelism when the host has cores), each shelling out on its own cadence,
+  feeding a shared world-state. The serial `for sensor in &config.sensors`
+  loop cannot express this, and #19 (sensor ordering foot-gun) is a direct
+  symptom — sequential sensors leak ordering into observed state.
+* **Replan on change, not on tick.** A world-state change must trigger the
+  planner; an idle tick that observes nothing new must not. This needs a
+  component that owns state and emits change events, decoupled from whatever
+  consumes them.
+* **Forward fit to the roadmap.** Plugins, multi-goal arbitration, and
+  hot-reload each independently want "a component with a lifecycle that talks
+  by messages and can be supervised/restarted." Retrofitting that topology
+  later is far costlier than starting on it now.
+* **`goap-planner` stays load-bearing and pure.** The sibling crate remains the
+  sole planning engine. `goap_planner::{State, Goal, Action, Plan, Planner}`
+  are the canonical types that flow *through* messages; no parallel
+  `ActorState`/`ActorPlan` types, no planning logic in the runtime layer. The
+  workspace layering rule (async/I/O only in `uncharles`) is non-negotiable.
+* **Operability.** Signal handling, graceful drain (never abort mid-action),
+  and restart-on-failure are production concerns the foundation must address —
+  `docs/adrs.md` lists replan triggers and signal handling as ADR-worthy
+  operability surface.
+
+## Considered Options
+
+* **Option A — Keep the serial loop, parallelise sensors with raw threads.**
+  Spawn a thread per sensor writing into a `Mutex<State>`; keep `run_loop`
+  otherwise intact.
+* **Option B — Actor model on `kameo` (0.20).** Each subsystem (world-state,
+  each sensor, planner, executor, goal-supervisor) is a kameo `Actor` with its
+  own mailbox, running on tokio; supervision via actor linking.
+* **Option C — Actor model on `ractor`.** Same topology, Erlang/`gen_server`
+  flavoured framework with a separate cluster crate.
+* **Option D — Hand-rolled tokio tasks + channels, no actor framework.** Model
+  each subsystem as a `tokio::spawn` task communicating over `mpsc`/`watch`
+  channels, write the supervision/restart logic ourselves.
+
+## Decision Outcome
+
+Chosen option: **"Option B — actor model on `kameo`"**. The actor model is the
+right shape for every roadmap item (each is "independent lifecycled components
+exchanging messages"), and kameo gives us that on the workspace's existing
+`tokio` runtime with the least ceremony: actors are plain structs implementing
+`Actor` + `Message<M>`, spawning returns a typed `ActorRef<A>`, and `tell`
+(fire-and-forget) / `ask` (request-reply) cover the message patterns we need.
+Lifecycle hooks (`on_start`, `on_stop`, `on_panic`, `on_link_died`) and the
+default `OneForOne` `supervision_strategy` give us the supervision tree
+without a hand-rolled restart loop (Option D).
+
+This **reverses an earlier, informal (non-ADR) decision to use `ractor`**
+recorded in project notes on 2026-06-12. That decision favoured ractor on
+adoption breadth and release stability; it is captured below under
+[Option C](#option-c--actor-model-on-ractor) and weighed honestly. The
+maintainer reversed it on 2026-06-18 after re-evaluating ergonomics: kameo's
+trait-per-message model maps directly onto our typed `goap-planner` payloads,
+and it keeps the dependency surface lean (the `remote`/libp2p stack is an
+opt-in feature, not pulled by default). No prior ADR exists to mark
+`superseded`; this is the first ADR on the runtime's concurrency model.
+
+The runtime contract this establishes:
+
+* **One owner per piece of state.** A `WorldStateActor` is the sole owner of
+  the `goap_planner::State` and the `Values` map (ADR 0003). Nothing else
+  mutates them; readers `ask` for a snapshot. This is the actor model's
+  state-ownership rule — *not* a revival of the old central serializer. The
+  thing being retired is one component doing sense→plan→act in lockstep, not
+  the existence of a state owner.
+* **Sensors are independent, continuous actors.** One `SensorActor` per
+  `SensorSpec`, each scheduling its own poll tick from `on_start`. Each tick
+  shells out (variable-latency subprocess → async per the Async-vs-Rayon rule)
+  and sends an `ApplyReading` message to the world-state. Sensors never
+  observe each other; ordering (#19) stops being load-bearing.
+* **Replan is edge-triggered on a state diff.** `WorldStateActor` computes
+  whether an applied reading actually changed the fact set or values, and emits
+  `StateChanged` only on a real delta. No-op ticks cause no planning.
+* **Planning stays in `goap-planner`, off the async workers.** A
+  `PlannerActor` wraps a single `Planner` (built once from the config's
+  actions) and the `Goal`. On `StateChanged` it snapshots state and runs
+  `planner.plan()` inside `spawn_blocking` (CPU-bound sync work must not block
+  a tokio worker — coding-guidelines.md). It does **not** hand-roll
+  "is the remaining plan still valid"; it just re-plans (cheap, per the
+  standing guardrail). Multiple changes arriving during a plan are
+  **coalesced**: a dirty flag triggers exactly one follow-up plan, never a
+  queue-storm.
+* **The executor runs the freshest plan and never aborts mid-action.** An
+  `ExecutorActor` holds the latest `Plan`; between actions it adopts the newest
+  plan received, executes one action's `cmd`, applies optimistic effects back
+  to the world-state (closing the loop), and continues. An in-flight action
+  always runs to completion (matches the existing `run.sh` contract).
+* **Goal arbitration has a seat from day one.** A `GoalSupervisor` routes
+  `StateChanged` to planner(s) and arbitrates which `NewPlan` reaches the
+  executor. Today it manages one goal; multi-goal lands here later as **N
+  independent `Planner::plan` calls arbitrated at this actor** — never joint
+  planning inside `goap-planner`.
+* **A root `AgentSupervisor`** links all of the above, applies the supervision
+  strategy (restart a crashed sensor; escalate a crashed world-state), and
+  translates `tokio::signal::ctrl_c` into a graceful drain.
+
+Scope: this ADR covers the concurrency foundation and the reactive-sensing
+behaviour. Plugins (IPC wire protocol), concurrent multi-goal arbitration
+policy, and config hot-reload are explicitly **out of scope** here — the
+topology is designed to absorb them, but each gets its own ADR when built.
+
+### Consequences
+
+* Good, because sensors run with true parallelism on tokio's multi-threaded
+  runtime, and replanning is reactive (edge-triggered on change) rather than
+  paced by a fixed loop interval.
+* Good, because `goap-planner` and `grafo` are untouched — the planner's
+  hot-path benchmarks keep their full signal, and the layering boundary holds.
+* Good, because the supervision tree, message types, and per-subsystem
+  lifecycles are exactly the seams plugins / multi-goal / hot-reload need, so
+  those features extend the topology instead of fighting it.
+* Good, because kameo runs on the `tokio` runtime the coding guidelines
+  already mandate, and its default `remote` feature is off, so the dependency
+  surface stays modest.
+* Bad, because `uncharles` gains a non-trivial async dependency surface
+  (`kameo` + `tokio` with `rt-multi-thread`/`process`/`time`/`signal`) and the
+  binary grows. The crate is now async at its core.
+* Bad, because debugging shifts from a linear loop to message-passing between
+  concurrent actors — harder to trace; mitigated by structured per-actor event
+  logging carried through to the existing JSON/NDJSON emitters.
+* Bad, because kameo's pre-1.0 release cadence (0.18→0.20 within six months)
+  means breaking upgrades are likely; pinned to `0.20` and isolated behind the
+  `actors` module so a future framework swap (or the rejected ractor option)
+  touches one module, not the whole runtime.
+* Bad, because we accept a small risk of replan churn under rapidly flapping
+  sensors; the diff-trigger + coalescing bound it, but a pathological config
+  can still keep the planner busy. Acceptable for v1; a debounce interval is a
+  follow-up if it bites.
+
+### Confirmation
+
+1. **Tests** — `cargo test -p uncharles` covers each actor in isolation
+   (spawn + `ask`/`tell` with side-effect-free `true`/`false`/`echo`
+   commands), an integration test reproducing the existing `three_step_config`
+   reaching goal-satisfied through the actor runtime, and a reactive test
+   proving a sensor flip mid-run triggers a replan that changes the executed
+   action. The existing `run.rs`/`config.rs` unit tests stay green (the pure
+   sensor/action helpers are reused, not rewritten).
+2. **`goap-planner` benchmarks** — unchanged crate ⇒ the bench gate
+   (`.github/workflows/bench.yml`) must report no movement. Any movement is a
+   layering violation (planner logic leaked into the runtime) and blocks merge.
+3. **Lint/format** — `cargo fmt --all`, `cargo clippy --all-targets
+   --all-features -- -D warnings`, `cargo test --workspace` clean.
+4. **CLI invariants** — `inspect` (pure planning) and one-shot non-execute
+   `run` are unchanged; their integration tests still pass, and `--execute`'s
+   JSON/NDJSON/pretty output keeps its documented shape.
+
+## Pros and Cons of the Options
+
+### Option A — serial loop + raw sensor threads
+
+* Good, because minimal new dependency surface.
+* Good, because the planner/executor code barely changes.
+* Bad, because it solves only parallel sensing — multi-goal, plugins, and
+  hot-reload still have nowhere to live, so the loop gets rewritten again soon.
+* Bad, because a shared `Mutex<State>` across N sensor threads reintroduces the
+  serialization point and the lock contention the actor model avoids by giving
+  state a single owning task.
+
+### Option B — actor model on kameo (chosen)
+
+* Good, because the topology fits every roadmap item, not just sensing.
+* Good, because trait-per-message (`Message<M>` with `type Reply`) maps cleanly
+  onto typed `goap-planner` payloads, and `tell`/`ask` cover our patterns.
+* Good, because supervision/lifecycle is provided, not hand-rolled.
+* Neutral, because it commits the runtime to `tokio` — already the workspace
+  runtime, so no new axis.
+* Bad, because pre-1.0 churn risk; mitigated by pinning and module isolation.
+
+### Option C — actor model on ractor
+
+The 2026-06-12 front-runner, reversed here.
+
+* Good, because broader real-world Cargo.toml adoption and patch-only 0.15.x
+  releases (more stable than kameo's 0.18→0.20 churn).
+* Good, because the `gen_server`/Erlang supervision model is battle-tested
+  (documented production use at Meta) and maps onto a supervision tree.
+* Bad, because its message dispatch (a single `Message` enum + `handle` match
+  per actor) is a looser fit for our typed-per-message `goap-planner` payloads
+  than kameo's trait-per-message; more boilerplate at every actor.
+* Bad, because the maintainer judged kameo's ergonomics materially better for
+  this codebase on re-evaluation — the deciding factor in the reversal.
+
+### Option D — hand-rolled tokio tasks + channels
+
+* Good, because zero framework dependency and full control.
+* Good, because the message types would still be our own `goap-planner` types.
+* Bad, because we'd reimplement supervision, restart, linking, and graceful
+  shutdown — exactly the wheel kameo/ractor already provide and test.
+* Bad, because every roadmap feature (plugins, multi-goal, hot-reload) would
+  grow its own ad-hoc lifecycle plumbing, accreting the bespoke framework we
+  chose not to depend on.
+
+## More Information
+
+* **Driving issues**: #17 (`--watch` mode for long-lived configs) and #19
+  (sensor ordering as a foot-gun) are both subsumed by the reactive runtime.
+  A dedicated `type:design` tracking issue for the broader actor pivot
+  (plugins / multi-goal / hot-reload) should be opened to host the follow-up
+  ADRs.
+* **Composes with ADR 0003**: the runtime `Values` map keeps living in
+  `uncharles`, now owned by `WorldStateActor` and travelling beside `State`
+  through `ApplyReading`/snapshot messages. No change to ADR 0003's contract.
+* **Reverses (informally)**: the 2026-06-12 project-note decision favouring
+  `ractor`. No ADR existed for it, so there is nothing to mark `superseded`;
+  this ADR is the record of record for the concurrency model.
+* **Follow-up ADRs expected**: plugin IPC wire protocol (JSON-RPC over stdio
+  is the current leaning), multi-goal arbitration policy, and config
+  hot-reload semantics. Each is out of scope here.
+* **Trigger to revisit**: a kameo breaking release that the `actors` module
+  cannot absorb cheaply, or a measured replan-churn problem that the
+  diff-trigger + coalescing cannot contain (would add a debounce interval).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -17,6 +17,7 @@ next free number.
 | 0002 | [Use uncharles as a post-apply IaC convergence watcher, not a CI replacement](./0002-uncharles-as-post-apply-iac-convergence-watcher.md) | accepted | 2026-05-03 |
 | 0003 | [Value-carrying facts live in the uncharles runtime, not in goap-planner's State](./0003-value-carrying-facts-runtime-side.md) | accepted | 2026-05-03 |
 | 0004 | [Publish `uncharles` to nixpkgs](./0004-publish-uncharles-to-nixpkgs.md) | accepted | 2026-05-17 |
+| 0005 | [Actor-based reactive runtime for uncharles (kameo)](./0005-actor-based-reactive-runtime.md) | proposed | 2026-06-18 |
 
 ## Status legend
 

--- a/uncharles/Cargo.toml
+++ b/uncharles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uncharles"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "Sense → plan → act runtime that drives goap-planner from a YAML config to automate shell tasks. The first automaton built in the Automata Atelier workspace."

--- a/uncharles/Cargo.toml
+++ b/uncharles/Cargo.toml
@@ -13,7 +13,15 @@ readme = "README.md"
 [dependencies]
 goap-planner = { path = "../goap-planner", version = "0.1" }
 clap = { version = "4", features = ["derive"] }
-ctrlc = { version = "3", features = ["termination"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+# Actor runtime (ADR 0005). kameo runs on tokio; the `remote`/libp2p feature
+# is off by default, keeping the dependency surface modest. Pinned to 0.20.x
+# because kameo is pre-1.0 and churns between minor releases — the `actors`
+# module isolates the API so an upgrade (or framework swap) is contained.
+kameo = "0.20"
+# Multi-threaded runtime is what gives sensors real OS-thread parallelism.
+# `process` for async sensor/action shell-outs, `time` for poll timers,
+# `signal` for graceful ctrl-c drain, `sync` for the output channel.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "time", "signal", "sync"] }

--- a/uncharles/Cargo.toml
+++ b/uncharles/Cargo.toml
@@ -25,3 +25,25 @@ kameo = "0.20"
 # `process` for async sensor/action shell-outs, `time` for poll timers,
 # `signal` for graceful ctrl-c drain, `sync` for the output channel.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "time", "signal", "sync"] }
+
+# Pedantic lint posture, scoped to uncharles only — this is the crate with the
+# async actor runtime, so its memory / async / parallelism surface gets the
+# strictest scrutiny. The sibling library crates (grafo, goap-planner) keep
+# their own lighter posture; pedantic is deliberately not applied there.
+#
+# `warn` here, promoted to errors by the CI clippy gate (`-D warnings`).
+# `priority = -1` lets the individual allows below win over the group default.
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+# Subjective / domain-intentional lints, allowed with intent so the gate stays
+# signal-rich rather than noisy. None touch the memory/async/parallelism surface
+# pedantic+nursery scrutinise — those stay fully enforced.
+struct_excessive_bools = "allow"   # CLI arg structs legitimately carry several flags
+float_cmp = "allow"                # tests compare exact, small, integer-valued plan costs
+too_many_lines = "allow"           # a couple of end-to-end test fns are long by nature
+similar_names = "allow"            # e.g. `argv`/`args` in CLI plumbing read fine
+
+[lints.rust]
+unused = { level = "warn", priority = -1 }
+rust_2018_idioms = { level = "warn", priority = -1 }

--- a/uncharles/README.md
+++ b/uncharles/README.md
@@ -6,14 +6,15 @@
 
 Sense → plan → act runtime that drives [`goap-planner`](../goap-planner/) from a YAML config. The first automaton built in the [Automata Atelier](../) workspace.
 
-`uncharles` reads a config that declares **sensors** (shell probes that read the world) and **actions** (shell commands with preconditions, effects, and a cost). On each cycle it runs the sensors to derive the current state, asks `goap-planner` for the cheapest plan to the goal, and either prints the plan or executes it step by step — re-sensing between steps so divergence triggers a replan rather than blind execution.
+`uncharles` reads a config that declares **sensors** (shell probes that read the world) and **actions** (shell commands with preconditions, effects, and a cost). Without `--execute` it does a single sense → plan and prints the cheapest plan to the goal. With `--execute` it runs the **reactive runtime** ([ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md)): sensors poll continuously and in parallel, a change to the world state triggers a replan, and an executor runs the freshest plan one action at a time — re-sensing and replanning so divergence reroutes execution rather than blindly continuing.
 
 ## Features
 
 - **YAML-first** — describe the world in declarative `sensors` / `actions` / `goal` lists. No Rust required for new automatons.
-- **Sense → plan → act loop** — each cycle is independent; replanning on divergence is the default failure mode.
-- **Plan-only or execute** — `--pretty` prints the plan; `--execute` runs it. Same config, two modes.
-- **Graceful shutdown** — `Ctrl+C` interrupts between steps, never mid-action.
+- **Reactive actor runtime** — under `--execute`, sensors run continuously and in parallel ([`kameo`](https://docs.rs/kameo) actors on `tokio`); world-state changes edge-trigger replanning and the executor always runs the freshest plan. See [ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md).
+- **Plan-only or execute** — without `--execute`, prints the plan (`--pretty` for human-readable); `--execute` runs it. Same config, two modes.
+- **Watcher mode** — `--execute --watch` stays up past goal-satisfied, acting again whenever the world next diverges.
+- **Graceful shutdown** — `Ctrl+C` drains the runtime cleanly between actions, never mid-action.
 
 ## Installation
 
@@ -71,11 +72,22 @@ Plan a sequence and print it:
 cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --pretty
 ```
 
-Execute the plan, re-sensing and replanning on divergence:
+Execute via the reactive runtime, re-sensing and replanning on divergence:
 
 ```sh
 cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --execute --pretty
 ```
+
+Stay up as a watcher (act again whenever the world next diverges), pacing
+sensor polls to once a second:
+
+```sh
+cargo run -p uncharles -- run --config uncharles/configs/podcast.yaml \
+  --execute --watch --interval-ms 1000
+```
+
+Under `--execute`, `--interval-ms` is the per-sensor poll cadence and
+`--max-iterations` caps the number of actions executed.
 
 ### `inspect` — visualise the state-action graph
 
@@ -217,7 +229,7 @@ Real configs covering different domains — read them as a tour of what the runt
 ```
 ┌─────────────────────────────────────────────┐
 │  uncharles  (this crate)                    │
-│   YAML · sensors · actions · loop · I/O     │
+│   YAML · sensors · actions · actors · I/O   │
 └────────────────────┬────────────────────────┘
                      │  uses
 ┌────────────────────▼────────────────────────┐
@@ -232,6 +244,8 @@ Real configs covering different domains — read them as a tour of what the runt
 ```
 
 Side effects (shell exec, YAML parsing, signal handling) live here, not in the layers below. Cloud-specific adapters and any future I/O glue belong in `uncharles` (or a sibling runtime crate), never in `goap-planner`.
+
+Under `--execute`, the runtime is a small tree of [`kameo`](https://docs.rs/kameo) actors on `tokio` ([ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md)): a sensor actor per `SensorSpec` (continuous, parallel), a world-state actor that owns the `State`/values and edge-triggers replans, a planner actor wrapping `goap-planner`, an executor actor, and a goal supervisor that arbitrates plans. `goap-planner`'s types are the messages — the actor layer wraps the planner, it never replaces it.
 
 ## Contributing
 

--- a/uncharles/README.md
+++ b/uncharles/README.md
@@ -6,14 +6,13 @@
 
 Sense → plan → act runtime that drives [`goap-planner`](../goap-planner/) from a YAML config. The first automaton built in the [Automata Atelier](../) workspace.
 
-`uncharles` reads a config that declares **sensors** (shell probes that read the world) and **actions** (shell commands with preconditions, effects, and a cost). Without `--execute` it does a single sense → plan and prints the cheapest plan to the goal. With `--execute` it runs the **reactive runtime** ([ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md)): sensors poll continuously and in parallel, a change to the world state triggers a replan, and an executor runs the freshest plan one action at a time — re-sensing and replanning so divergence reroutes execution rather than blindly continuing.
+`uncharles` reads a config that declares **sensors** (shell probes that read the world) and **actions** (shell commands with preconditions, effects, and a cost). Without `--execute` it does a single sense → plan and prints the cheapest plan to the goal. With `--execute` it runs as a **perpetual automaton** ([ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md)) — a long-lived daemon that senses the environment continuously and in parallel, and when it detects a change it plans and acts toward the goal; once the goal is reached it returns to sensing, waiting for the world to diverge again. It runs until stopped (SIGINT/SIGTERM). Use `--once` to drive to the goal a single time and exit (CI/scripting).
 
 ## Features
 
 - **YAML-first** — describe the world in declarative `sensors` / `actions` / `goal` lists. No Rust required for new automatons.
-- **Reactive actor runtime** — under `--execute`, sensors run continuously and in parallel ([`kameo`](https://docs.rs/kameo) actors on `tokio`); world-state changes edge-trigger replanning and the executor always runs the freshest plan. See [ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md).
-- **Plan-only or execute** — without `--execute`, prints the plan (`--pretty` for human-readable); `--execute` runs it. Same config, two modes.
-- **Watcher mode** — `--execute --watch` stays up past goal-satisfied, acting again whenever the world next diverges.
+- **Perpetual automaton (daemon)** — `--execute` runs a long-lived service ([`kameo`](https://docs.rs/kameo) actors on `tokio`): sensors poll continuously and in parallel, world-state changes edge-trigger replanning, the executor drives the freshest plan to the goal, then it returns to sensing. Drains gracefully on SIGINT/SIGTERM. See [ADR 0005](../docs/adrs/0005-actor-based-reactive-runtime.md).
+- **Plan-only, run, or one-shot** — without `--execute`, prints the plan (`--pretty` for human-readable); `--execute` runs the daemon; `--execute --once` drives to the goal a single time and exits (definitive exit code for CI/scripting).
 - **Graceful shutdown** — `Ctrl+C` drains the runtime cleanly between actions, never mid-action.
 
 ## Installation
@@ -72,18 +71,19 @@ Plan a sequence and print it:
 cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --pretty
 ```
 
-Execute via the reactive runtime, re-sensing and replanning on divergence:
-
-```sh
-cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --execute --pretty
-```
-
-Stay up as a watcher (act again whenever the world next diverges), pacing
-sensor polls to once a second:
+Run as a daemon — sense continuously, act on divergence, return to sensing
+(pacing sensor polls to once a second). Stop with Ctrl+C / SIGTERM:
 
 ```sh
 cargo run -p uncharles -- run --config uncharles/configs/podcast.yaml \
-  --execute --watch --interval-ms 1000
+  --execute --interval-ms 1000
+```
+
+One-shot: drive to the goal a single time and exit (CI/scripting) — exits 0
+on goal-satisfied, 1 if the goal is unreachable:
+
+```sh
+cargo run -p uncharles -- run --config uncharles/configs/deploy.yaml --execute --once --pretty
 ```
 
 Under `--execute`, `--interval-ms` is the per-sensor poll cadence and

--- a/uncharles/src/actors/executor.rs
+++ b/uncharles/src/actors/executor.rs
@@ -1,0 +1,195 @@
+//! Runs the freshest plan, one action at a time (ADR 0005).
+//!
+//! The executor holds the latest adopted plan. It runs exactly one action (the
+//! plan's first step) off-thread, never aborting an in-flight action, then
+//! feeds the optimistic effects back to the world. Applying effects triggers a
+//! replan, whose fresh plan arrives as the next [`AdoptPlan`] — so between
+//! actions the executor always picks up the newest plan, never a stale tail.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use kameo::prelude::*;
+
+use crate::actors::goal_supervisor::GoalSupervisorActor;
+use crate::actors::messages::{
+    ActionFinished, AdoptPlan, ApplyActionEffects, SetExecutorSupervisor, SetWorldState, Terminate,
+};
+use crate::actors::world_state::WorldStateActor;
+use crate::actors::{EventSink, RuntimeEvent, RuntimeOutcome};
+use crate::config::ActionSpec;
+use crate::run::{execute_action, find_action_spec};
+
+/// Spawn arguments for [`ExecutorActor`].
+pub struct ExecutorArgs {
+    pub actions: Arc<Vec<ActionSpec>>,
+    pub events: EventSink,
+    /// Safety cap on the number of actions executed before the run is stopped.
+    pub max_actions: usize,
+}
+
+/// Executes plans, one action per replan cycle.
+pub struct ExecutorActor {
+    actions: Arc<Vec<ActionSpec>>,
+    world: Option<ActorRef<WorldStateActor>>,
+    supervisor: Option<ActorRef<GoalSupervisorActor>>,
+    events: EventSink,
+    /// The freshest non-empty plan + the snapshot it was planned from.
+    latest: Option<AdoptPlan>,
+    /// True while an action is running off-thread.
+    busy: bool,
+    executed: usize,
+    max_actions: usize,
+}
+
+impl ExecutorActor {
+    async fn terminate(&self, outcome: RuntimeOutcome) {
+        if let Some(sup) = &self.supervisor {
+            let _ = sup.tell(Terminate(outcome)).send().await;
+        }
+    }
+
+    /// Start the first step of the latest plan, if idle and one exists.
+    async fn try_run_next(&mut self, me: ActorRef<Self>) {
+        if self.busy {
+            return;
+        }
+        let Some(adopt) = self.latest.take() else {
+            return;
+        };
+
+        if self.executed >= self.max_actions {
+            self.terminate(RuntimeOutcome::MaxActionsReached {
+                max: self.max_actions,
+            })
+            .await;
+            return;
+        }
+
+        // The supervisor only ever sends non-empty plans.
+        let step = adopt.plan.steps[0].clone();
+        let spec = match find_action_spec(&self.actions, &step) {
+            Ok(spec) => spec.clone(),
+            Err(e) => {
+                self.terminate(RuntimeOutcome::Error {
+                    message: e.to_string(),
+                })
+                .await;
+                return;
+            }
+        };
+
+        self.busy = true;
+        let values = adopt.snapshot.values.clone();
+        let spec_for_run = spec.clone();
+        tokio::spawn(async move {
+            // Subprocess wait is variable-latency I/O → off the async worker.
+            let result =
+                tokio::task::spawn_blocking(move || execute_action(&spec_for_run, &values))
+                    .await
+                    .map_err(|e| format!("action task panicked: {e}"))
+                    .and_then(|r| r.map_err(|e| e.to_string()));
+            let _ = me.tell(ActionFinished { result, spec }).send().await;
+        });
+    }
+}
+
+impl Actor for ExecutorActor {
+    type Args = ExecutorArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            actions: args.actions,
+            world: None,
+            supervisor: None,
+            events: args.events,
+            latest: None,
+            busy: false,
+            executed: 0,
+            max_actions: args.max_actions,
+        })
+    }
+}
+
+impl Message<AdoptPlan> for ExecutorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: AdoptPlan, ctx: &mut Context<Self, Self::Reply>) {
+        // Keep only the freshest plan; if mid-action, this supersedes whatever
+        // we'd have run next.
+        self.latest = Some(msg);
+        let me = ctx.actor_ref().clone();
+        self.try_run_next(me).await;
+    }
+}
+
+impl Message<ActionFinished> for ExecutorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ActionFinished, _ctx: &mut Context<Self, Self::Reply>) {
+        self.busy = false;
+        // Discard any plan that arrived mid-action: it was computed from
+        // pre-effect state. The post-effect replan below yields the fresh one.
+        self.latest = None;
+
+        let result = match msg.result {
+            Ok(result) => result,
+            Err(message) => {
+                // The action failed to even spawn — a hard, terminal error.
+                self.terminate(RuntimeOutcome::Error { message }).await;
+                return;
+            }
+        };
+
+        let _ = self.events.send(RuntimeEvent::Executed {
+            result: result.clone(),
+        });
+        self.executed += 1;
+
+        let effects = if result.success {
+            // Optimistically apply the action's declared effects; sensors will
+            // correct the world if reality disagrees.
+            Some((msg.spec.adds.clone(), msg.spec.removes.clone()))
+        } else if let Some(on_failure) = &msg.spec.on_failure {
+            // Recoverable failure: apply the on_failure effects and let the
+            // next replan route around it. The action's own adds/removes are
+            // the success-path contract and are deliberately skipped.
+            Some((on_failure.add.clone(), on_failure.remove.clone()))
+        } else {
+            // Fatal failure.
+            self.terminate(RuntimeOutcome::ActionFailed {
+                name: result.name,
+                exit_code: result.exit_code,
+                stderr: result.stderr,
+            })
+            .await;
+            return;
+        };
+
+        if let (Some((adds, removes)), Some(world)) = (effects, &self.world) {
+            let _ = world
+                .tell(ApplyActionEffects { adds, removes })
+                .send()
+                .await;
+        }
+        // No auto-run here: we wait for the post-effect replan's AdoptPlan,
+        // guaranteeing the next action is chosen from post-effect state.
+    }
+}
+
+impl Message<SetWorldState> for ExecutorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetWorldState, _ctx: &mut Context<Self, Self::Reply>) {
+        self.world = Some(msg.0);
+    }
+}
+
+impl Message<SetExecutorSupervisor> for ExecutorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetExecutorSupervisor, _ctx: &mut Context<Self, Self::Reply>) {
+        self.supervisor = Some(msg.0);
+    }
+}

--- a/uncharles/src/actors/goal_supervisor.rs
+++ b/uncharles/src/actors/goal_supervisor.rs
@@ -1,0 +1,149 @@
+//! Routes changes to planner(s) and arbitrates which plan executes (ADR 0005).
+//!
+//! Today it drives a single goal: forward each [`StateChanged`] to the planner,
+//! and on [`PlanReady`] decide the terminal cases (no plan / goal satisfied) or
+//! dispatch a runnable plan to the executor. It is the seat where multi-goal
+//! arbitration lands later — N independent planners, results compared here —
+//! never joint planning inside `goap-planner`.
+//!
+//! In `watch` mode the goal-satisfied and no-plan results are not terminal: the
+//! runtime keeps sensing and replans when the world next changes (issue #17).
+
+use std::convert::Infallible;
+
+use kameo::prelude::*;
+use tokio::sync::oneshot;
+
+use crate::actors::executor::ExecutorActor;
+use crate::actors::messages::{
+    AdoptPlan, PlanReady, PlanRequest, SetExecutor, SetPlanners, StateChanged, Terminate,
+};
+use crate::actors::planner::PlannerActor;
+use crate::actors::{EventSink, RuntimeEvent, RuntimeOutcome};
+
+/// Spawn arguments for [`GoalSupervisorActor`].
+pub struct GoalSupervisorArgs {
+    pub events: EventSink,
+    /// Fires once with the terminal outcome. The driver awaits it.
+    pub completion: oneshot::Sender<RuntimeOutcome>,
+    /// Keep running past goal-satisfied / no-plan (watcher mode).
+    pub watch: bool,
+}
+
+/// Arbitrates plans for the executor; owns the terminal-outcome channel.
+pub struct GoalSupervisorActor {
+    planners: Vec<ActorRef<PlannerActor>>,
+    executor: Option<ActorRef<ExecutorActor>>,
+    events: EventSink,
+    completion: Option<oneshot::Sender<RuntimeOutcome>>,
+    watch: bool,
+    done: bool,
+}
+
+impl GoalSupervisorActor {
+    /// Fire the terminal outcome exactly once.
+    fn finish(&mut self, outcome: RuntimeOutcome) {
+        if self.done {
+            return;
+        }
+        self.done = true;
+        if let Some(tx) = self.completion.take() {
+            let _ = tx.send(outcome);
+        }
+    }
+}
+
+impl Actor for GoalSupervisorActor {
+    type Args = GoalSupervisorArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            planners: Vec::new(),
+            executor: None,
+            events: args.events,
+            completion: Some(args.completion),
+            watch: args.watch,
+            done: false,
+        })
+    }
+}
+
+impl Message<StateChanged> for GoalSupervisorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: StateChanged, _ctx: &mut Context<Self, Self::Reply>) {
+        if self.done {
+            return;
+        }
+        for planner in &self.planners {
+            let _ = planner.tell(PlanRequest(msg.0.clone())).send().await;
+        }
+    }
+}
+
+impl Message<PlanReady> for GoalSupervisorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: PlanReady, _ctx: &mut Context<Self, Self::Reply>) {
+        if self.done {
+            return;
+        }
+        match msg.result {
+            Err(message) => {
+                let _ = self.events.send(RuntimeEvent::Planned { plan: None });
+                self.finish(RuntimeOutcome::Error { message });
+            }
+            Ok(None) => {
+                let _ = self.events.send(RuntimeEvent::Planned { plan: None });
+                if !self.watch {
+                    self.finish(RuntimeOutcome::NoPlan);
+                }
+            }
+            Ok(Some(plan)) if plan.steps.is_empty() => {
+                let _ = self.events.send(RuntimeEvent::Planned { plan: Some(plan) });
+                if !self.watch {
+                    self.finish(RuntimeOutcome::GoalSatisfied);
+                }
+            }
+            Ok(Some(plan)) => {
+                let _ = self.events.send(RuntimeEvent::Planned {
+                    plan: Some(plan.clone()),
+                });
+                if let Some(executor) = &self.executor {
+                    let _ = executor
+                        .tell(AdoptPlan {
+                            plan,
+                            snapshot: msg.snapshot,
+                        })
+                        .send()
+                        .await;
+                }
+            }
+        }
+    }
+}
+
+impl Message<Terminate> for GoalSupervisorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Terminate, _ctx: &mut Context<Self, Self::Reply>) {
+        self.finish(msg.0);
+    }
+}
+
+impl Message<SetPlanners> for GoalSupervisorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetPlanners, _ctx: &mut Context<Self, Self::Reply>) {
+        self.planners = msg.0;
+    }
+}
+
+impl Message<SetExecutor> for GoalSupervisorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetExecutor, _ctx: &mut Context<Self, Self::Reply>) {
+        self.executor = Some(msg.0);
+    }
+}

--- a/uncharles/src/actors/messages.rs
+++ b/uncharles/src/actors/messages.rs
@@ -1,0 +1,126 @@
+//! Message types exchanged between the runtime's actors (ADR 0005).
+//!
+//! Every payload that carries planning data uses `goap-planner`'s own types
+//! (`State`, `Plan`) — there are deliberately no parallel "actor" state or plan
+//! types. Wiring messages (`Set*`) inject the cross-references that can't be
+//! known at spawn time, resolving the actor graph's cycles in a second phase.
+
+use goap_planner::{Plan, State};
+use kameo::prelude::*;
+
+use crate::actors::RuntimeOutcome;
+use crate::actors::executor::ExecutorActor;
+use crate::actors::goal_supervisor::GoalSupervisorActor;
+use crate::actors::planner::PlannerActor;
+use crate::actors::world_state::WorldStateActor;
+use crate::config::ActionSpec;
+use crate::run::{ActionResult, SensorReading, Values};
+
+/// Immutable snapshot of the world handed to planners and the executor.
+#[derive(Clone, Debug, Reply)]
+pub struct WorldSnapshot {
+    pub state: State,
+    pub values: Values,
+}
+
+// --- WorldStateActor inbox ------------------------------------------------
+
+/// A sensor reported. Applied to the world; notifies the subscriber only if it
+/// actually changes state (sensor noise must not trigger replans).
+#[derive(Debug)]
+pub struct ApplyReading(pub SensorReading);
+
+/// An executed action's effects. Always notifies the subscriber — the executor
+/// needs the post-effect state to plan its next step.
+#[derive(Debug)]
+pub struct ApplyActionEffects {
+    pub adds: Vec<String>,
+    pub removes: Vec<String>,
+}
+
+/// Force a snapshot push to the subscriber, regardless of change. Kicks the
+/// first plan once wiring is complete (covers zero-sensor configs too).
+#[derive(Debug)]
+pub struct Bootstrap;
+
+/// Read-only snapshot of the current world (used by tests and tooling).
+#[derive(Debug)]
+pub struct Snapshot;
+
+/// Inject the change subscriber (the goal supervisor).
+#[derive(Debug)]
+pub struct SetSubscriber(pub ActorRef<GoalSupervisorActor>);
+
+// --- PlannerActor inbox ---------------------------------------------------
+
+/// Plan for this snapshot. Coalesced: while a plan is in flight, the latest
+/// request is stashed and run once the current one completes.
+#[derive(Debug)]
+pub struct PlanRequest(pub WorldSnapshot);
+
+/// Internal: an off-thread `plan()` call finished.
+#[derive(Debug)]
+pub struct PlanComputed {
+    pub result: Result<Option<Plan>, String>,
+    pub snapshot: WorldSnapshot,
+}
+
+/// Inject the goal supervisor the planner reports results to.
+#[derive(Debug)]
+pub struct SetGoalSupervisor(pub ActorRef<GoalSupervisorActor>);
+
+// --- GoalSupervisorActor inbox --------------------------------------------
+
+/// The world changed; replan.
+#[derive(Debug)]
+pub struct StateChanged(pub WorldSnapshot);
+
+/// A planner produced a result for arbitration.
+#[derive(Debug)]
+pub struct PlanReady {
+    pub result: Result<Option<Plan>, String>,
+    pub snapshot: WorldSnapshot,
+}
+
+/// The executor reached a terminal condition (failure, cap, exec error).
+#[derive(Debug)]
+pub struct Terminate(pub RuntimeOutcome);
+
+/// Inject the planner pool (one per goal; one for now).
+#[derive(Debug)]
+pub struct SetPlanners(pub Vec<ActorRef<PlannerActor>>);
+
+/// Inject the executor plans are dispatched to.
+#[derive(Debug)]
+pub struct SetExecutor(pub ActorRef<ExecutorActor>);
+
+// --- ExecutorActor inbox --------------------------------------------------
+
+/// Adopt a plan to execute. Always non-empty (the supervisor handles the
+/// empty/none terminal cases). The snapshot supplies values for env injection.
+#[derive(Debug)]
+pub struct AdoptPlan {
+    pub plan: Plan,
+    pub snapshot: WorldSnapshot,
+}
+
+/// Internal: an off-thread action `cmd` finished.
+#[derive(Debug)]
+pub struct ActionFinished {
+    pub result: Result<ActionResult, String>,
+    pub spec: ActionSpec,
+}
+
+/// Inject the world-state actor effects are reported to.
+#[derive(Debug)]
+pub struct SetWorldState(pub ActorRef<WorldStateActor>);
+
+/// Inject the supervisor terminal conditions are reported to.
+#[derive(Debug)]
+pub struct SetExecutorSupervisor(pub ActorRef<GoalSupervisorActor>);
+
+// --- SensorActor inbox ----------------------------------------------------
+
+/// Poll tick: read the sensor and report.
+#[derive(Debug)]
+pub struct Tick;

--- a/uncharles/src/actors/mod.rs
+++ b/uncharles/src/actors/mod.rs
@@ -1,0 +1,99 @@
+//! Actor-based reactive runtime (ADR 0005).
+//!
+//! Replaces the synchronous sense → plan → act loop with a topology of
+//! [`kameo`] actors running on a multi-threaded `tokio` runtime:
+//!
+//! ```text
+//!   SensorActor×N ──ApplyReading──▶ WorldStateActor ──StateChanged──▶ GoalSupervisorActor
+//!                                         ▲                                    │
+//!                                         │                            PlanRequest │ PlanReady
+//!                                  ApplyActionEffects                          ▼
+//!                                         │                              PlannerActor
+//!                                   ExecutorActor ◀────────AdoptPlan───────────┘
+//! ```
+//!
+//! - **Sensors** run continuously and in parallel, each on its own poll
+//!   cadence, shelling out off-thread and reporting readings.
+//! - **WorldState** is the sole owner of [`goap_planner::State`] and the
+//!   ADR-0003 `Values` map. It edge-triggers a replan only when a reading
+//!   actually changes the world (action effects always trigger one — the
+//!   executor needs the next step).
+//! - **Planner** wraps a single [`goap_planner::Planner`], runs `plan()` off
+//!   the async workers via `spawn_blocking`, and coalesces bursts of changes
+//!   into one in-flight plan.
+//! - **Executor** runs the freshest plan one action at a time, never aborting
+//!   mid-action, and feeds optimistic effects back to the world.
+//! - **GoalSupervisor** routes changes to planner(s) and arbitrates which plan
+//!   reaches the executor — the seat where multi-goal arbitration lands later.
+//!
+//! `goap-planner` is untouched: its `State`, `Goal`, `Action`, `Plan`, and
+//! `Planner` types are the payloads that travel through the messages here.
+
+pub mod executor;
+pub mod goal_supervisor;
+pub mod messages;
+pub mod planner;
+pub mod runtime;
+pub mod sensor;
+pub mod world_state;
+
+use goap_planner::Plan;
+
+use crate::run::{ActionResult, Values};
+
+pub use runtime::{AgentRuntime, RuntimeParams};
+
+/// Sender half of the runtime's event channel. Every actor holds a clone and
+/// pushes [`RuntimeEvent`]s for the driver task to render (JSON/NDJSON/pretty).
+pub type EventSink = tokio::sync::mpsc::UnboundedSender<RuntimeEvent>;
+
+/// An observable moment in the reactive runtime, surfaced to the operator.
+///
+/// Mirrors the old loop's `sensed`/`planned`/`executed`/`complete` event shape
+/// so the CLI's structured output stays recognisable, but each `Sensed` is now
+/// per-sensor (sensors no longer run as one batched sweep).
+#[derive(Debug, Clone)]
+pub enum RuntimeEvent {
+    /// One sensor reported. `changed` is whether this reading moved the world
+    /// state (and therefore whether it triggered a replan).
+    Sensed {
+        sensor: String,
+        success: bool,
+        added: Vec<String>,
+        removed: Vec<String>,
+        captured: Option<String>,
+        changed: bool,
+        state: Vec<String>,
+        values: Values,
+    },
+    /// The planner produced a result. `None` = no plan exists; `Some(empty)` =
+    /// goal already satisfied; `Some(steps)` = a path to execute.
+    Planned { plan: Option<Plan> },
+    /// An action finished executing.
+    Executed { result: ActionResult },
+    /// The run reached a terminal state. Emitted once, last, by the driver.
+    Complete { outcome: RuntimeOutcome },
+}
+
+/// Why the reactive runtime stopped. Drives the process exit code.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuntimeOutcome {
+    /// The goal is satisfied (planner returned an empty plan). Exit 0.
+    GoalSatisfied,
+    /// No plan exists from the current state. Exit 1.
+    NoPlan,
+    /// An action's `cmd` exited non-zero and it had no `on_failure` clause.
+    /// Exit 1.
+    ActionFailed {
+        name: String,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    /// The executed-action safety cap was hit. Exit 1.
+    MaxActionsReached { max: usize },
+    /// SIGINT drained the runtime. Exit 1.
+    Interrupted,
+    /// A planner error, an action that failed to spawn, or a planner naming an
+    /// action absent from the config. Exit 2.
+    Error { message: String },
+}

--- a/uncharles/src/actors/mod.rs
+++ b/uncharles/src/actors/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! - **Sensors** run continuously and in parallel, each on its own poll
 //!   cadence, shelling out off-thread and reporting readings.
-//! - **WorldState** is the sole owner of [`goap_planner::State`] and the
+//! - **`WorldState`** is the sole owner of [`goap_planner::State`] and the
 //!   ADR-0003 `Values` map. It edge-triggers a replan only when a reading
 //!   actually changes the world (action effects always trigger one — the
 //!   executor needs the next step).
@@ -23,7 +23,7 @@
 //!   into one in-flight plan.
 //! - **Executor** runs the freshest plan one action at a time, never aborting
 //!   mid-action, and feeds optimistic effects back to the world.
-//! - **GoalSupervisor** routes changes to planner(s) and arbitrates which plan
+//! - **`GoalSupervisor`** routes changes to planner(s) and arbitrates which plan
 //!   reaches the executor — the seat where multi-goal arbitration lands later.
 //!
 //! `goap-planner` is untouched: its `State`, `Goal`, `Action`, `Plan`, and
@@ -76,7 +76,7 @@ pub enum RuntimeEvent {
 }
 
 /// Why the reactive runtime stopped. Drives the process exit code.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeOutcome {
     /// The goal is satisfied (planner returned an empty plan). Exit 0.
     GoalSatisfied,

--- a/uncharles/src/actors/planner.rs
+++ b/uncharles/src/actors/planner.rs
@@ -1,0 +1,117 @@
+//! Wraps the one and only [`goap_planner::Planner`] (ADR 0005).
+//!
+//! On every [`PlanRequest`] it runs `plan()` off the async workers (CPU-bound
+//! sync work must not block a `tokio` worker — see the workspace coding
+//! guidelines) and reports the result to the goal supervisor. Bursts of
+//! changes are coalesced: while a plan is in flight, only the most recent
+//! request is kept, and exactly one follow-up plan runs when it lands. No
+//! "is the remaining plan still valid" guessing — replanning is the mechanism.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use goap_planner::{Goal, Planner};
+use kameo::prelude::*;
+
+use crate::actors::goal_supervisor::GoalSupervisorActor;
+use crate::actors::messages::{
+    PlanComputed, PlanReady, PlanRequest, SetGoalSupervisor, WorldSnapshot,
+};
+
+/// Spawn arguments for [`PlannerActor`].
+pub struct PlannerArgs {
+    pub planner: Arc<Planner>,
+    pub goal: Goal,
+}
+
+/// Owns a planner + goal; computes plans off-thread and coalesces requests.
+pub struct PlannerActor {
+    planner: Arc<Planner>,
+    goal: Goal,
+    supervisor: Option<ActorRef<GoalSupervisorActor>>,
+    busy: bool,
+    pending: Option<WorldSnapshot>,
+}
+
+impl PlannerActor {
+    /// Launch an off-thread `plan()` for `snapshot`, reporting back to `self`.
+    fn spawn_plan(&self, snapshot: WorldSnapshot, me: ActorRef<Self>) {
+        let planner = Arc::clone(&self.planner);
+        let goal = self.goal.clone();
+        let snapshot_for_reply = snapshot.clone();
+        tokio::spawn(async move {
+            let state = snapshot.state.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                planner.plan(&state, &goal).map_err(|e| e.to_string())
+            })
+            .await
+            .unwrap_or_else(|e| Err(format!("planner task panicked: {e}")));
+            let _ = me
+                .tell(PlanComputed {
+                    result,
+                    snapshot: snapshot_for_reply,
+                })
+                .send()
+                .await;
+        });
+    }
+}
+
+impl Actor for PlannerActor {
+    type Args = PlannerArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            planner: args.planner,
+            goal: args.goal,
+            supervisor: None,
+            busy: false,
+            pending: None,
+        })
+    }
+}
+
+impl Message<PlanRequest> for PlannerActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: PlanRequest, ctx: &mut Context<Self, Self::Reply>) {
+        if self.busy {
+            // Coalesce: keep only the freshest snapshot.
+            self.pending = Some(msg.0);
+        } else {
+            self.busy = true;
+            self.spawn_plan(msg.0, ctx.actor_ref().clone());
+        }
+    }
+}
+
+impl Message<PlanComputed> for PlannerActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: PlanComputed, ctx: &mut Context<Self, Self::Reply>) {
+        if let Some(sup) = &self.supervisor {
+            let _ = sup
+                .tell(PlanReady {
+                    result: msg.result,
+                    snapshot: msg.snapshot,
+                })
+                .send()
+                .await;
+        }
+        // Drain a coalesced request, if one arrived while we were planning.
+        if let Some(next) = self.pending.take() {
+            self.spawn_plan(next, ctx.actor_ref().clone());
+        } else {
+            self.busy = false;
+        }
+    }
+}
+
+impl Message<SetGoalSupervisor> for PlannerActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetGoalSupervisor, _ctx: &mut Context<Self, Self::Reply>) {
+        self.supervisor = Some(msg.0);
+    }
+}

--- a/uncharles/src/actors/runtime.rs
+++ b/uncharles/src/actors/runtime.rs
@@ -34,8 +34,33 @@ pub struct RuntimeParams {
     pub interval_ms: u64,
     /// Safety cap on actions executed before the run stops.
     pub max_actions: usize,
-    /// Keep running past goal-satisfied / no-plan (watcher mode, issue #17).
+    /// Run as a perpetual automaton: when the goal is satisfied (or no plan
+    /// currently exists) the runtime returns to sensing and waits for the world
+    /// to diverge again, rather than exiting. This is the daemon default;
+    /// `--once` sets it to `false` for a one-shot drive-to-goal-and-exit run.
     pub watch: bool,
+}
+
+/// Completes on the first service-stop signal.
+///
+/// On Unix that is SIGINT **or** SIGTERM — the signals an operator, systemd, or
+/// Docker uses to stop a daemon — so uncharles drains gracefully on either
+/// rather than being killed abruptly. Elsewhere it falls back to Ctrl-C.
+async fn shutdown_signal() {
+    // SIGINT is handled portably via `ctrl_c()`; SIGTERM needs the Unix-only
+    // stream. If the SIGTERM handler can't be installed we still honour SIGINT.
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut sigterm) = signal(SignalKind::terminate()) {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = sigterm.recv() => {}
+            }
+            return;
+        }
+    }
+    let _ = tokio::signal::ctrl_c().await;
 }
 
 /// Entry point for the actor runtime.
@@ -128,12 +153,17 @@ impl AgentRuntime {
         // 6. Kick the first plan from the swept initial state.
         let _ = world.tell(Bootstrap).send().await;
 
-        // 7. Render events until a terminal outcome or SIGINT.
+        // 7. Render events until a terminal outcome or a stop signal. uncharles
+        //    runs as a long-lived service, so it drains on SIGTERM (systemd /
+        //    Docker `stop`) as well as SIGINT. The signal future is created once
+        //    and polled by reference so handlers aren't re-registered per event.
+        let shutdown = shutdown_signal();
+        tokio::pin!(shutdown);
         let outcome = loop {
             tokio::select! {
                 biased;
                 res = &mut done_rx => break res.unwrap_or(RuntimeOutcome::Interrupted),
-                _ = tokio::signal::ctrl_c() => break RuntimeOutcome::Interrupted,
+                () = &mut shutdown => break RuntimeOutcome::Interrupted,
                 maybe = ev_rx.recv() => {
                     if let Some(ev) = maybe {
                         on_event(&ev);

--- a/uncharles/src/actors/runtime.rs
+++ b/uncharles/src/actors/runtime.rs
@@ -1,0 +1,327 @@
+//! The runtime driver (ADR 0005).
+//!
+//! Builds the actor graph, performs an initial parallel sensor sweep so the
+//! first plan sees every sensor's opening reading, wires the cross-references,
+//! starts continuous sensing, and then renders events until a terminal outcome
+//! or SIGINT. This task is the root of the supervision tree: it owns the actor
+//! handles and tears them down gracefully on shutdown (an in-flight action
+//! always runs to completion — actions are never aborted mid-flight).
+
+use std::sync::Arc;
+
+use goap_planner::Planner;
+use kameo::prelude::*;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::actors::executor::{ExecutorActor, ExecutorArgs};
+use crate::actors::goal_supervisor::{GoalSupervisorActor, GoalSupervisorArgs};
+use crate::actors::messages::{
+    ApplyReading, Bootstrap, SetExecutor, SetExecutorSupervisor, SetGoalSupervisor, SetPlanners,
+    SetSubscriber, SetWorldState,
+};
+use crate::actors::planner::{PlannerActor, PlannerArgs};
+use crate::actors::sensor::{SensorActor, SensorArgs};
+use crate::actors::world_state::{WorldStateActor, WorldStateArgs};
+use crate::actors::{RuntimeEvent, RuntimeOutcome};
+use crate::config::Config;
+use crate::run::{build_actions, build_goal, read_sensor};
+
+/// Tunables for one run of the reactive runtime.
+pub struct RuntimeParams {
+    /// Facts seeded into the initial state before sensors run.
+    pub seed: Vec<String>,
+    /// Per-sensor poll cadence in milliseconds (`0` = as fast as work allows).
+    pub interval_ms: u64,
+    /// Safety cap on actions executed before the run stops.
+    pub max_actions: usize,
+    /// Keep running past goal-satisfied / no-plan (watcher mode, issue #17).
+    pub watch: bool,
+}
+
+/// Entry point for the actor runtime.
+pub struct AgentRuntime;
+
+impl AgentRuntime {
+    /// Drive the reactive runtime to a terminal [`RuntimeOutcome`].
+    ///
+    /// `on_event` is called for every [`RuntimeEvent`] in render order, with a
+    /// final [`RuntimeEvent::Complete`] last. Returns the outcome so the caller
+    /// can map it to a process exit code.
+    pub async fn run(
+        config: &Config,
+        params: RuntimeParams,
+        mut on_event: impl FnMut(&RuntimeEvent),
+    ) -> RuntimeOutcome {
+        let (ev_tx, mut ev_rx) = mpsc::unbounded_channel::<RuntimeEvent>();
+        let (done_tx, mut done_rx) = oneshot::channel::<RuntimeOutcome>();
+
+        let planner = Arc::new(Planner::new(build_actions(&config.actions)));
+        let goal = build_goal(&config.goal);
+        let actions = Arc::new(config.actions.clone());
+
+        // 1. World — sole state owner, no subscriber yet.
+        let world = WorldStateActor::spawn(WorldStateArgs {
+            seed: params.seed.clone(),
+            events: ev_tx.clone(),
+        });
+
+        // 2. Initial sweep — sequential, in config order. The first plan must
+        //    see a deterministic baseline, and some configs declare sensors
+        //    with ordering-dependent side effects (a discovery sensor that
+        //    stages work a later sensor observes — the issue #19 foot-gun).
+        //    Running the *one-time* baseline sweep in declared order preserves
+        //    those configs; steady-state sensing below is fully parallel.
+        //    Applying before the subscriber is wired means these readings don't
+        //    each kick a premature plan — the first plan sees the whole sweep.
+        for spec in &config.sensors {
+            let spec = spec.clone();
+            let read = tokio::task::spawn_blocking(move || read_sensor(&spec)).await;
+            if let Ok(Ok(reading)) = read {
+                // `ask` so it is applied before we wire the subscriber.
+                let _ = world.ask(ApplyReading(reading)).await;
+            }
+        }
+
+        // 3. Planner, executor, supervisor.
+        let planner_ref = PlannerActor::spawn(PlannerArgs { planner, goal });
+        let executor_ref = ExecutorActor::spawn(ExecutorArgs {
+            actions,
+            events: ev_tx.clone(),
+            max_actions: params.max_actions,
+        });
+        let goal_sup = GoalSupervisorActor::spawn(GoalSupervisorArgs {
+            events: ev_tx.clone(),
+            completion: done_tx,
+            watch: params.watch,
+        });
+
+        // 4. Wire the graph's cycles (second phase).
+        let _ = world.tell(SetSubscriber(goal_sup.clone())).send().await;
+        let _ = planner_ref
+            .tell(SetGoalSupervisor(goal_sup.clone()))
+            .send()
+            .await;
+        let _ = goal_sup
+            .tell(SetPlanners(vec![planner_ref.clone()]))
+            .send()
+            .await;
+        let _ = goal_sup
+            .tell(SetExecutor(executor_ref.clone()))
+            .send()
+            .await;
+        let _ = executor_ref.tell(SetWorldState(world.clone())).send().await;
+        let _ = executor_ref
+            .tell(SetExecutorSupervisor(goal_sup.clone()))
+            .send()
+            .await;
+
+        // 5. Start continuous sensing.
+        let mut sensors = Vec::with_capacity(config.sensors.len());
+        for spec in &config.sensors {
+            sensors.push(SensorActor::spawn(SensorArgs {
+                spec: Arc::new(spec.clone()),
+                world: world.clone(),
+                interval_ms: params.interval_ms,
+            }));
+        }
+
+        // 6. Kick the first plan from the swept initial state.
+        let _ = world.tell(Bootstrap).send().await;
+
+        // 7. Render events until a terminal outcome or SIGINT.
+        let outcome = loop {
+            tokio::select! {
+                biased;
+                res = &mut done_rx => break res.unwrap_or(RuntimeOutcome::Interrupted),
+                _ = tokio::signal::ctrl_c() => break RuntimeOutcome::Interrupted,
+                maybe = ev_rx.recv() => {
+                    if let Some(ev) = maybe {
+                        on_event(&ev);
+                    }
+                }
+            }
+        };
+
+        // 8. Tear down gracefully, drain any straggler events, emit Complete.
+        for sensor in &sensors {
+            let _ = sensor.stop_gracefully().await;
+        }
+        let _ = executor_ref.stop_gracefully().await;
+        let _ = planner_ref.stop_gracefully().await;
+        let _ = goal_sup.stop_gracefully().await;
+        let _ = world.stop_gracefully().await;
+        drop(ev_tx);
+        while let Ok(ev) = ev_rx.try_recv() {
+            on_event(&ev);
+        }
+        on_event(&RuntimeEvent::Complete {
+            outcome: outcome.clone(),
+        });
+        outcome
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ActionSpec, Effects, GoalSpec, SensorSpec};
+
+    fn sensor(name: &str) -> SensorSpec {
+        SensorSpec {
+            name: name.into(),
+            cmd: vec!["true".into()],
+            on_success: None,
+            on_failure: None,
+            capture: None,
+        }
+    }
+
+    fn action(name: &str, cmd: &[&str], requires: &[&str], adds: &[&str]) -> ActionSpec {
+        ActionSpec {
+            name: name.into(),
+            cost: 1.0,
+            requires: requires.iter().map(|s| s.to_string()).collect(),
+            forbids: Vec::new(),
+            adds: adds.iter().map(|s| s.to_string()).collect(),
+            removes: Vec::new(),
+            cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
+            on_failure: None,
+        }
+    }
+
+    fn params() -> RuntimeParams {
+        RuntimeParams {
+            seed: Vec::new(),
+            interval_ms: 0,
+            max_actions: 100,
+            watch: false,
+        }
+    }
+
+    async fn run_collect(config: &Config, p: RuntimeParams) -> (RuntimeOutcome, Vec<RuntimeEvent>) {
+        let mut events = Vec::new();
+        let outcome = AgentRuntime::run(config, p, |e| events.push(e.clone())).await;
+        (outcome, events)
+    }
+
+    fn executed(events: &[RuntimeEvent]) -> Vec<(String, bool)> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                RuntimeEvent::Executed { result } => Some((result.name.clone(), result.success)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drives_three_step_config_to_goal_through_replanning() {
+        let config = Config {
+            sensors: vec![sensor("heartbeat")],
+            actions: vec![
+                action("do_a", &["true"], &["heartbeat"], &["a_done"]),
+                action("do_b", &["true"], &["a_done"], &["b_done"]),
+                action("do_c", &["true"], &["b_done"], &["finished"]),
+            ],
+            goal: GoalSpec {
+                requires: vec!["finished".into()],
+                forbids: Vec::new(),
+            },
+        };
+        let (outcome, events) = run_collect(&config, params()).await;
+        assert_eq!(outcome, RuntimeOutcome::GoalSatisfied);
+        let names: Vec<String> = executed(&events).into_iter().map(|(n, _)| n).collect();
+        assert_eq!(names, vec!["do_a", "do_b", "do_c"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reports_no_plan_when_goal_unreachable() {
+        let config = Config {
+            sensors: vec![sensor("heartbeat")],
+            actions: vec![action("do_a", &["true"], &["heartbeat"], &["a_done"])],
+            goal: GoalSpec {
+                requires: vec!["unreachable".into()],
+                forbids: Vec::new(),
+            },
+        };
+        let (outcome, _) = run_collect(&config, params()).await;
+        assert_eq!(outcome, RuntimeOutcome::NoPlan);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fatal_action_failure_terminates_with_action_failed() {
+        let config = Config {
+            sensors: vec![sensor("heartbeat")],
+            actions: vec![action(
+                "do_a",
+                &["sh", "-c", "exit 7"],
+                &["heartbeat"],
+                &["finished"],
+            )],
+            goal: GoalSpec {
+                requires: vec!["finished".into()],
+                forbids: Vec::new(),
+            },
+        };
+        let (outcome, _) = run_collect(&config, params()).await;
+        match outcome {
+            RuntimeOutcome::ActionFailed {
+                name, exit_code, ..
+            } => {
+                assert_eq!(name, "do_a");
+                assert_eq!(exit_code, Some(7));
+            }
+            other => panic!("expected ActionFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recoverable_failure_replans_through_alternative_path() {
+        // `try_fast` fails; its on_failure unlocks the slow path. The reactive
+        // replan must route around the failure and reach the goal via `try_slow`.
+        let config = Config {
+            sensors: vec![sensor("heartbeat")],
+            actions: vec![
+                ActionSpec {
+                    name: "try_fast".into(),
+                    cost: 1.0,
+                    requires: vec!["heartbeat".into(), "fast".into()],
+                    forbids: Vec::new(),
+                    adds: vec!["finished".into()],
+                    removes: Vec::new(),
+                    cmd: Some(vec!["false".into()]),
+                    on_failure: Some(Effects {
+                        add: vec!["slow".into()],
+                        remove: vec!["fast".into()],
+                    }),
+                },
+                ActionSpec {
+                    name: "try_slow".into(),
+                    cost: 5.0,
+                    requires: vec!["slow".into()],
+                    forbids: Vec::new(),
+                    adds: vec!["finished".into()],
+                    removes: Vec::new(),
+                    cmd: Some(vec!["true".into()]),
+                    on_failure: None,
+                },
+            ],
+            goal: GoalSpec {
+                requires: vec!["finished".into()],
+                forbids: Vec::new(),
+            },
+        };
+        let p = RuntimeParams {
+            seed: vec!["fast".into()],
+            interval_ms: 0,
+            max_actions: 100,
+            watch: false,
+        };
+        let (outcome, events) = run_collect(&config, p).await;
+        assert_eq!(outcome, RuntimeOutcome::GoalSatisfied);
+        assert_eq!(
+            executed(&events),
+            vec![("try_fast".into(), false), ("try_slow".into(), true)],
+        );
+    }
+}

--- a/uncharles/src/actors/runtime.rs
+++ b/uncharles/src/actors/runtime.rs
@@ -180,11 +180,14 @@ mod tests {
         ActionSpec {
             name: name.into(),
             cost: 1.0,
-            requires: requires.iter().map(|s| s.to_string()).collect(),
+            requires: requires
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             forbids: Vec::new(),
-            adds: adds.iter().map(|s| s.to_string()).collect(),
+            adds: adds.iter().map(std::string::ToString::to_string).collect(),
             removes: Vec::new(),
-            cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
+            cmd: Some(cmd.iter().map(std::string::ToString::to_string).collect()),
             on_failure: None,
         }
     }

--- a/uncharles/src/actors/sensor.rs
+++ b/uncharles/src/actors/sensor.rs
@@ -40,7 +40,7 @@ impl Actor for SensorActor {
         // Drive the poll loop from a detached task that pings this actor. It
         // exits when the actor goes away (tell returns an error), so the loop
         // is bounded by the actor's lifetime.
-        let me = actor_ref.clone();
+        let me = actor_ref;
         let interval = Duration::from_millis(args.interval_ms);
         tokio::spawn(async move {
             loop {
@@ -63,12 +63,11 @@ impl Message<Tick> for SensorActor {
     async fn handle(&mut self, _msg: Tick, _ctx: &mut Context<Self, Self::Reply>) {
         let spec = Arc::clone(&self.spec);
         // Subprocess wait is variable-latency I/O → off the async worker.
-        let reading = match tokio::task::spawn_blocking(move || read_sensor(&spec)).await {
-            Ok(Ok(reading)) => reading,
-            // Command failed to spawn (e.g. missing binary). Skip this tick;
-            // the next one retries. A permanently-broken sensor leaves its
-            // fact unchanged rather than crashing the runtime.
-            Ok(Err(_)) | Err(_) => return,
+        // Command failed to spawn (e.g. missing binary) or the blocking task
+        // panicked → skip this tick; the next one retries. A permanently-broken
+        // sensor leaves its fact unchanged rather than crashing the runtime.
+        let Ok(Ok(reading)) = tokio::task::spawn_blocking(move || read_sensor(&spec)).await else {
+            return;
         };
         let _ = self.world.tell(ApplyReading(reading)).send().await;
     }

--- a/uncharles/src/actors/sensor.rs
+++ b/uncharles/src/actors/sensor.rs
@@ -1,0 +1,75 @@
+//! A continuously-polling sensor (ADR 0005).
+//!
+//! One actor per `SensorSpec`. Each schedules its own poll ticks from
+//! `on_start`, so sensors run independently and in parallel — the blocking
+//! shell-out runs on `tokio`'s blocking pool, giving real OS-thread
+//! parallelism when the host has cores. Readings are reported to the
+//! world-state actor; this actor never touches state directly.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use kameo::prelude::*;
+
+use crate::actors::messages::{ApplyReading, Tick};
+use crate::actors::world_state::WorldStateActor;
+use crate::config::SensorSpec;
+use crate::run::read_sensor;
+
+/// Spawn arguments for [`SensorActor`].
+pub struct SensorArgs {
+    pub spec: Arc<SensorSpec>,
+    pub world: ActorRef<WorldStateActor>,
+    /// Delay between this sensor's poll ticks. `0` means poll as fast as the
+    /// shell-out allows.
+    pub interval_ms: u64,
+}
+
+/// Polls one sensor command on a fixed cadence.
+pub struct SensorActor {
+    spec: Arc<SensorSpec>,
+    world: ActorRef<WorldStateActor>,
+}
+
+impl Actor for SensorActor {
+    type Args = SensorArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        // Drive the poll loop from a detached task that pings this actor. It
+        // exits when the actor goes away (tell returns an error), so the loop
+        // is bounded by the actor's lifetime.
+        let me = actor_ref.clone();
+        let interval = Duration::from_millis(args.interval_ms);
+        tokio::spawn(async move {
+            loop {
+                if me.tell(Tick).send().await.is_err() {
+                    break;
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+        Ok(Self {
+            spec: args.spec,
+            world: args.world,
+        })
+    }
+}
+
+impl Message<Tick> for SensorActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: Tick, _ctx: &mut Context<Self, Self::Reply>) {
+        let spec = Arc::clone(&self.spec);
+        // Subprocess wait is variable-latency I/O → off the async worker.
+        let reading = match tokio::task::spawn_blocking(move || read_sensor(&spec)).await {
+            Ok(Ok(reading)) => reading,
+            // Command failed to spawn (e.g. missing binary). Skip this tick;
+            // the next one retries. A permanently-broken sensor leaves its
+            // fact unchanged rather than crashing the runtime.
+            Ok(Err(_)) | Err(_) => return,
+        };
+        let _ = self.world.tell(ApplyReading(reading)).send().await;
+    }
+}

--- a/uncharles/src/actors/world_state.rs
+++ b/uncharles/src/actors/world_state.rs
@@ -1,0 +1,245 @@
+//! The sole owner of the world state (ADR 0005).
+//!
+//! Holds `goap-planner`'s [`State`] and the ADR-0003 [`Values`] map. Sensor
+//! readings and action effects flow in as messages; the only thing that ever
+//! mutates the world is this actor handling one message at a time. Readers take
+//! a [`WorldSnapshot`]. This is the actor model's single-owner rule, not a
+//! revival of the old central serializer — nothing here plans or executes.
+
+use std::collections::BTreeSet;
+use std::convert::Infallible;
+
+use goap_planner::State;
+use kameo::prelude::*;
+
+use crate::actors::goal_supervisor::GoalSupervisorActor;
+use crate::actors::messages::{
+    ApplyActionEffects, ApplyReading, Bootstrap, SetSubscriber, Snapshot, StateChanged,
+    WorldSnapshot,
+};
+use crate::actors::{EventSink, RuntimeEvent};
+use crate::run::{Values, apply_reading};
+
+/// Spawn arguments for [`WorldStateActor`].
+pub struct WorldStateArgs {
+    /// Facts seeded into the initial state before any sensor runs.
+    pub seed: Vec<String>,
+    /// Event channel for `sensed` events.
+    pub events: EventSink,
+}
+
+/// Owns the world; edge-triggers replanning on change.
+pub struct WorldStateActor {
+    state: State,
+    values: Values,
+    subscriber: Option<ActorRef<GoalSupervisorActor>>,
+    events: EventSink,
+}
+
+impl WorldStateActor {
+    fn snapshot(&self) -> WorldSnapshot {
+        WorldSnapshot {
+            state: self.state.clone(),
+            values: self.values.clone(),
+        }
+    }
+
+    fn sorted_facts(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.state.facts().map(String::from).collect();
+        v.sort();
+        v
+    }
+
+    /// Push the current snapshot to the subscriber, if one is wired.
+    async fn notify(&self) {
+        if let Some(sub) = &self.subscriber {
+            let _ = sub.tell(StateChanged(self.snapshot())).send().await;
+        }
+    }
+}
+
+impl Actor for WorldStateActor {
+    type Args = WorldStateArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            state: State::from_facts(args.seed),
+            values: Values::new(),
+            subscriber: None,
+            events: args.events,
+        })
+    }
+}
+
+impl Message<ApplyReading> for WorldStateActor {
+    /// Whether the reading changed the world (and so triggered a replan).
+    type Reply = bool;
+
+    async fn handle(&mut self, msg: ApplyReading, _ctx: &mut Context<Self, Self::Reply>) -> bool {
+        let reading = msg.0;
+
+        let facts_before: BTreeSet<String> = self.state.facts().map(String::from).collect();
+        let values_before = self.values.clone();
+        apply_reading(&reading, &mut self.state, &mut self.values);
+        let facts_after: BTreeSet<String> = self.state.facts().map(String::from).collect();
+        let changed = facts_before != facts_after || values_before != self.values;
+
+        let _ = self.events.send(RuntimeEvent::Sensed {
+            sensor: reading.name,
+            success: reading.success,
+            added: reading.added,
+            removed: reading.removed,
+            captured: reading.captured_value,
+            changed,
+            state: self.sorted_facts(),
+            values: self.values.clone(),
+        });
+
+        if changed {
+            self.notify().await;
+        }
+        changed
+    }
+}
+
+impl Message<ApplyActionEffects> for WorldStateActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ApplyActionEffects, _ctx: &mut Context<Self, Self::Reply>) {
+        // Removing a fact drops its value too — ADR 0003's atomic-remove rule.
+        for fact in &msg.removes {
+            self.state.remove(fact);
+            self.values.remove(fact);
+        }
+        for fact in &msg.adds {
+            self.state.insert(fact.clone());
+        }
+        // Always notify: a finished action means the executor needs the next
+        // step, even if the optimistic effects happened to be a no-op.
+        self.notify().await;
+    }
+}
+
+impl Message<Bootstrap> for WorldStateActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: Bootstrap, _ctx: &mut Context<Self, Self::Reply>) {
+        self.notify().await;
+    }
+}
+
+impl Message<Snapshot> for WorldStateActor {
+    type Reply = WorldSnapshot;
+
+    async fn handle(
+        &mut self,
+        _msg: Snapshot,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> WorldSnapshot {
+        self.snapshot()
+    }
+}
+
+impl Message<SetSubscriber> for WorldStateActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetSubscriber, _ctx: &mut Context<Self, Self::Reply>) {
+        self.subscriber = Some(msg.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::SensorReading;
+    use tokio::sync::mpsc;
+
+    fn reading(
+        name: &str,
+        added: &[&str],
+        removed: &[&str],
+        captured: Option<&str>,
+    ) -> SensorReading {
+        SensorReading {
+            name: name.into(),
+            success: true,
+            added: added.iter().map(|s| s.to_string()).collect(),
+            removed: removed.iter().map(|s| s.to_string()).collect(),
+            captured_value: captured.map(|s| s.to_string()),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_reading_reports_change_then_no_change() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let world = WorldStateActor::spawn(WorldStateArgs {
+            seed: Vec::new(),
+            events: tx,
+        });
+        // First time a fact is added → changed.
+        let first = world
+            .ask(ApplyReading(reading("x", &["x"], &[], None)))
+            .await
+            .unwrap();
+        assert!(first, "adding a new fact must report a change");
+        // Same fact again → no change (edge-trigger: no replan).
+        let second = world
+            .ask(ApplyReading(reading("x", &["x"], &[], None)))
+            .await
+            .unwrap();
+        assert!(
+            !second,
+            "re-observing the same fact must not report a change"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn snapshot_reflects_applied_readings_and_captured_values() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let world = WorldStateActor::spawn(WorldStateArgs {
+            seed: vec!["seed".into()],
+            events: tx,
+        });
+        let _ = world
+            .ask(ApplyReading(reading(
+                "target",
+                &["target"],
+                &[],
+                Some("v1"),
+            )))
+            .await
+            .unwrap();
+        let snap = world.ask(Snapshot).await.unwrap();
+        assert!(snap.state.contains("seed"));
+        assert!(snap.state.contains("target"));
+        assert_eq!(snap.values.get("target").map(String::as_str), Some("v1"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn removing_a_fact_drops_its_value() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let world = WorldStateActor::spawn(WorldStateArgs {
+            seed: Vec::new(),
+            events: tx,
+        });
+        let _ = world
+            .ask(ApplyReading(reading(
+                "target",
+                &["target"],
+                &[],
+                Some("v1"),
+            )))
+            .await
+            .unwrap();
+        // A failing-style reading that removes the fact also drops its value
+        // (ADR 0003 atomic-remove).
+        let _ = world
+            .ask(ApplyReading(reading("target", &[], &["target"], None)))
+            .await
+            .unwrap();
+        let snap = world.ask(Snapshot).await.unwrap();
+        assert!(!snap.state.contains("target"));
+        assert!(!snap.values.contains_key("target"));
+    }
+}

--- a/uncharles/src/actors/world_state.rs
+++ b/uncharles/src/actors/world_state.rs
@@ -164,9 +164,12 @@ mod tests {
         SensorReading {
             name: name.into(),
             success: true,
-            added: added.iter().map(|s| s.to_string()).collect(),
-            removed: removed.iter().map(|s| s.to_string()).collect(),
-            captured_value: captured.map(|s| s.to_string()),
+            added: added.iter().map(std::string::ToString::to_string).collect(),
+            removed: removed
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+            captured_value: captured.map(std::string::ToString::to_string),
         }
     }
 

--- a/uncharles/src/config.rs
+++ b/uncharles/src/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
 /// `Values` map under this sensor's `name`. Action commands then receive the
 /// value as `UNCHARLES_FACT_<NAME>=<value>` whenever the action's `requires`
 /// list mentions a fact with a captured value. See ADR 0003.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SensorSpec {
     pub name: String,
@@ -58,7 +58,7 @@ pub struct Effects {
     pub remove: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ActionSpec {
     pub name: String,

--- a/uncharles/src/config.rs
+++ b/uncharles/src/config.rs
@@ -500,7 +500,7 @@ mod tests {
 
     #[test]
     fn parses_action_without_cmd_for_pure_planning() {
-        let yaml = r#"
+        let yaml = r"
             sensors: []
             actions:
               - name: imaginary
@@ -509,7 +509,7 @@ mod tests {
                 adds: [b]
             goal:
               requires: [b]
-        "#;
+        ";
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let a = &config.actions[0];
         assert_eq!(a.name, "imaginary");
@@ -523,13 +523,13 @@ mod tests {
     #[test]
     fn rejects_unknown_top_level_field() {
         // deny_unknown_fields catches typos in the schema.
-        let yaml = r#"
+        let yaml = r"
             sensors: []
             actions: []
             goal:
               requires: [done]
             unrelated_field: 42
-        "#;
+        ";
         let err = serde_yaml::from_str::<Config>(yaml).unwrap_err();
         assert!(
             err.to_string().contains("unrelated_field"),
@@ -573,10 +573,10 @@ mod tests {
 
     #[test]
     fn requires_goal_section() {
-        let yaml = r#"
+        let yaml = r"
             sensors: []
             actions: []
-        "#;
+        ";
         let err = serde_yaml::from_str::<Config>(yaml).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("goal"));
     }

--- a/uncharles/src/inspect.rs
+++ b/uncharles/src/inspect.rs
@@ -62,7 +62,7 @@ pub struct StaticAnalysis {
 }
 
 impl StaticAnalysis {
-    pub fn is_clean(&self) -> bool {
+    pub const fn is_clean(&self) -> bool {
         self.orphan_actions.is_empty()
             && self.unreachable_goal_facts.is_empty()
             && self.dead_end_states.is_empty()
@@ -97,7 +97,7 @@ pub fn analyse(config: &Config, graph: &StateGraph) -> StaticAnalysis {
     let mut dead_end_states: Vec<usize> = (0..graph.states.len())
         .filter(|i| graph.is_dead_end(*i) && !goal_set.contains(i))
         .collect();
-    dead_end_states.sort();
+    dead_end_states.sort_unstable();
 
     StaticAnalysis {
         orphan_actions,
@@ -390,7 +390,9 @@ pub fn render_dot(
             "  // *** TRUNCATED — max_states reached; this is a partial graph ***"
         );
     }
-    if !analysis.is_clean() {
+    if analysis.is_clean() {
+        let _ = writeln!(out, "  // static analysis: clean");
+    } else {
         let _ = writeln!(out, "  // static-analysis findings:");
         for (action, fact) in &analysis.orphan_actions {
             let _ = writeln!(
@@ -411,8 +413,6 @@ pub fn render_dot(
                 format_facts(&graph.states[i].facts)
             );
         }
-    } else {
-        let _ = writeln!(out, "  // static analysis: clean");
     }
 
     let _ = writeln!(out, "}}");
@@ -517,7 +517,9 @@ pub fn render_mermaid(
             "%% *** TRUNCATED — max_states reached; this is a partial graph ***"
         );
     }
-    if !analysis.is_clean() {
+    if analysis.is_clean() {
+        let _ = writeln!(out, "%% static analysis: clean");
+    } else {
         let _ = writeln!(out, "%% static-analysis findings:");
         for (action, fact) in &analysis.orphan_actions {
             let _ = writeln!(
@@ -531,8 +533,6 @@ pub fn render_mermaid(
         for &i in &analysis.dead_end_states {
             let _ = writeln!(out, "%%   - dead-end state: S{i}");
         }
-    } else {
-        let _ = writeln!(out, "%% static analysis: clean");
     }
 
     out

--- a/uncharles/src/main.rs
+++ b/uncharles/src/main.rs
@@ -62,11 +62,13 @@ struct RunArgs {
     #[arg(long, value_name = "FACT")]
     have: Vec<String>,
 
-    /// Execute the plan: start the reactive runtime (ADR 0005) — sensors poll
-    /// continuously and in parallel, world-state changes trigger replanning,
-    /// and the executor runs the freshest plan, applying each action's effects
-    /// and replanning until the goal is satisfied (or, with `--watch`, forever).
-    /// Without this flag, uncharles does a single sense → plan and exits.
+    /// Run the automaton (ADR 0005). This is a **perpetual** sense → plan →
+    /// act → sense loop: sensors poll continuously and in parallel, a change to
+    /// the world state triggers a replan, the executor drives the freshest plan
+    /// to the goal, and once the goal is reached the automaton returns to
+    /// sensing — waiting for the world to diverge again. It runs until SIGINT
+    /// (or an unrecoverable action failure). Without this flag, uncharles does a
+    /// single sense → plan and exits. See `--once` to drive to the goal and exit.
     #[arg(long)]
     execute: bool,
 
@@ -75,17 +77,18 @@ struct RunArgs {
     max_iterations: usize,
 
     /// Per-sensor poll cadence in milliseconds when `--execute` is set.
-    /// `0` (the default) polls as fast as each shell-out allows, which suits
-    /// "drive to goal" configs. Set a non-zero value to pace "watch the world"
-    /// configs whose sensors hit an external API.
+    /// `0` (the default) polls as fast as each shell-out allows. Set a non-zero
+    /// value to pace sensors that hit an external API every cycle.
     #[arg(long, default_value_t = 0, value_name = "MS")]
     interval_ms: u64,
 
-    /// Keep running after the goal is satisfied (or no plan exists): stay up,
-    /// keep sensing, and act again when the world next diverges. Only
-    /// meaningful with `--execute`. SIGINT stops the watcher cleanly.
+    /// One-shot mode: drive to the goal once and exit instead of the default
+    /// perpetual loop. With `--once`, a satisfied goal exits 0 and an
+    /// unreachable goal exits 1 (no-plan) — useful for CI and scripting where
+    /// you want a definitive outcome rather than a long-lived automaton. Only
+    /// meaningful with `--execute`.
     #[arg(long)]
-    watch: bool,
+    once: bool,
 
     /// Human-readable output. Defaults to JSON (or NDJSON in execute mode).
     #[arg(long)]
@@ -236,7 +239,8 @@ fn run_execute_mode(args: &RunArgs, config: &Config) -> ExitCode {
         seed: args.have.clone(),
         interval_ms: args.interval_ms,
         max_actions: args.max_iterations,
-        watch: args.watch,
+        // Perpetual by default; `--once` opts into drive-to-goal-and-exit.
+        watch: !args.once,
     };
 
     let outcome = runtime.block_on(AgentRuntime::run(config, params, |event| {
@@ -244,11 +248,13 @@ fn run_execute_mode(args: &RunArgs, config: &Config) -> ExitCode {
     }));
 
     match outcome {
-        RuntimeOutcome::GoalSatisfied => ExitCode::SUCCESS,
+        // A signal-driven drain is a clean service stop (systemd/Docker send
+        // SIGTERM to stop a daemon), as is reaching the goal in `--once` mode.
+        RuntimeOutcome::GoalSatisfied | RuntimeOutcome::Interrupted => ExitCode::SUCCESS,
+        // `--once`-only terminals: the goal is unreachable or the cap was hit.
         RuntimeOutcome::NoPlan
         | RuntimeOutcome::ActionFailed { .. }
-        | RuntimeOutcome::MaxActionsReached { .. }
-        | RuntimeOutcome::Interrupted => ExitCode::from(1),
+        | RuntimeOutcome::MaxActionsReached { .. } => ExitCode::from(1),
         RuntimeOutcome::Error { .. } => ExitCode::from(2),
     }
 }

--- a/uncharles/src/main.rs
+++ b/uncharles/src/main.rs
@@ -141,7 +141,7 @@ fn main() -> ExitCode {
 
     match cli.command {
         Command::Run(args) => run_command(args),
-        Command::Inspect(args) => inspect_command(args),
+        Command::Inspect(args) => inspect_command(&args),
     }
 }
 
@@ -257,7 +257,7 @@ fn run_execute_mode(args: &RunArgs, config: &Config) -> ExitCode {
 // `inspect` subcommand — issue #22
 // ---------------------------------------------------------------------------
 
-fn inspect_command(args: InspectArgs) -> ExitCode {
+fn inspect_command(args: &InspectArgs) -> ExitCode {
     let raw = match fs::read_to_string(&args.config) {
         Ok(s) => s,
         Err(e) => {
@@ -459,9 +459,7 @@ fn emit_runtime_event_pretty(event: &RuntimeEvent) {
             } => {
                 println!(
                     "[stop]   action `{name}` failed (exit {})",
-                    exit_code
-                        .map(|c| c.to_string())
-                        .unwrap_or_else(|| "?".into()),
+                    exit_code.map_or_else(|| "?".into(), |c| c.to_string()),
                 );
                 if !stderr.is_empty() {
                     for line in stderr.lines().take(10) {

--- a/uncharles/src/main.rs
+++ b/uncharles/src/main.rs
@@ -5,12 +5,17 @@
 //! Subcommands:
 //!
 //! - `run` — load the config, run sensors, plan, and (with `--execute`)
-//!   actually run the plan. The default subcommand for backward compatibility
-//!   — `uncharles --config X` is parsed as `uncharles run --config X`.
+//!   drive the actor-based reactive runtime (ADR 0005): sensors poll
+//!   continuously and in parallel, world-state changes trigger replanning, and
+//!   the executor runs the freshest plan. Without `--execute` it does a single
+//!   sense → plan and prints the result. The default subcommand for backward
+//!   compatibility — `uncharles --config X` is parsed as `uncharles run
+//!   --config X`.
 //! - `inspect` — load the config and print the static structure plus the
 //!   bounded reachable state-action graph, *without* running sensors or
 //!   actions. For visual debugging.
 
+mod actors;
 mod config;
 mod inspect;
 mod run;
@@ -18,13 +23,12 @@ mod run;
 use std::fs;
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+use actors::{AgentRuntime, RuntimeEvent, RuntimeOutcome, RuntimeParams};
 use config::Config;
-use run::{LoopEvent, LoopOutcome, Outcome, RunError, run_loop, sense_and_plan};
+use run::{Outcome, RunError, sense_and_plan};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -58,24 +62,30 @@ struct RunArgs {
     #[arg(long, value_name = "FACT")]
     have: Vec<String>,
 
-    /// Execute the plan: actually run each action's `cmd`, re-sense, replan,
-    /// and continue until the goal is satisfied. Without this flag,
-    /// uncharles only prints the plan and exits.
+    /// Execute the plan: start the reactive runtime (ADR 0005) — sensors poll
+    /// continuously and in parallel, world-state changes trigger replanning,
+    /// and the executor runs the freshest plan, applying each action's effects
+    /// and replanning until the goal is satisfied (or, with `--watch`, forever).
+    /// Without this flag, uncharles does a single sense → plan and exits.
     #[arg(long)]
     execute: bool,
 
-    /// Safety cap on loop iterations when `--execute` is set. Each iteration
-    /// runs all sensors, plans, and executes one action.
+    /// Safety cap on the number of actions executed when `--execute` is set.
     #[arg(long, default_value_t = 100)]
     max_iterations: usize,
 
-    /// Minimum delay (milliseconds) between iterations of the execute loop.
-    /// `0` (the default) runs as fast as work allows, which suits "drive to
-    /// goal" configs. Set a non-zero value to pace "watch the world" configs
-    /// where sensors poll an external API. The sleep is interruptible —
-    /// SIGINT wakes it within ~50 ms regardless of the configured value.
+    /// Per-sensor poll cadence in milliseconds when `--execute` is set.
+    /// `0` (the default) polls as fast as each shell-out allows, which suits
+    /// "drive to goal" configs. Set a non-zero value to pace "watch the world"
+    /// configs whose sensors hit an external API.
     #[arg(long, default_value_t = 0, value_name = "MS")]
     interval_ms: u64,
+
+    /// Keep running after the goal is satisfied (or no plan exists): stay up,
+    /// keep sensing, and act again when the world next diverges. Only
+    /// meaningful with `--execute`. SIGINT stops the watcher cleanly.
+    #[arg(long)]
+    watch: bool,
 
     /// Human-readable output. Defaults to JSON (or NDJSON in execute mode).
     #[arg(long)]
@@ -207,40 +217,39 @@ fn run_command(args: RunArgs) -> ExitCode {
 }
 
 fn run_execute_mode(args: &RunArgs, config: &Config) -> ExitCode {
-    let interrupted = Arc::new(AtomicBool::new(false));
-    let signal_flag = Arc::clone(&interrupted);
-    if let Err(e) = ctrlc::set_handler(move || {
-        signal_flag.store(true, Ordering::Relaxed);
-    }) {
-        eprintln!("error: failed to install signal handler: {e}");
-        return ExitCode::from(2);
-    }
+    // The reactive runtime needs a multi-threaded runtime so sensors get real
+    // OS-thread parallelism (ADR 0005). `enable_all` turns on the timer and
+    // signal drivers the poll loop and graceful ctrl-c drain depend on.
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start async runtime: {e}");
+            return ExitCode::from(2);
+        }
+    };
 
     let pretty = args.pretty;
-    let result = run_loop(
-        config,
-        args.have.clone(),
-        args.max_iterations,
-        args.interval_ms,
-        Arc::clone(&interrupted),
-        |event| emit_event(&event, pretty),
-    );
+    let params = RuntimeParams {
+        seed: args.have.clone(),
+        interval_ms: args.interval_ms,
+        max_actions: args.max_iterations,
+        watch: args.watch,
+    };
 
-    match result {
-        Ok(outcome) => {
-            emit_loop_outcome(&outcome, pretty);
-            match outcome {
-                LoopOutcome::GoalSatisfied { .. } => ExitCode::SUCCESS,
-                LoopOutcome::NoPlan { .. }
-                | LoopOutcome::ActionFailed { .. }
-                | LoopOutcome::MaxIterationsReached { .. }
-                | LoopOutcome::Interrupted { .. } => ExitCode::from(1),
-            }
-        }
-        Err(e) => {
-            emit_error(&e, pretty);
-            ExitCode::from(2)
-        }
+    let outcome = runtime.block_on(AgentRuntime::run(config, params, |event| {
+        emit_runtime_event(event, pretty);
+    }));
+
+    match outcome {
+        RuntimeOutcome::GoalSatisfied => ExitCode::SUCCESS,
+        RuntimeOutcome::NoPlan
+        | RuntimeOutcome::ActionFailed { .. }
+        | RuntimeOutcome::MaxActionsReached { .. }
+        | RuntimeOutcome::Interrupted => ExitCode::from(1),
+        RuntimeOutcome::Error { .. } => ExitCode::from(2),
     }
 }
 
@@ -385,112 +394,71 @@ fn emit_outcome(outcome: &Outcome, pretty: bool) {
     println!("{v}");
 }
 
-fn emit_event(event: &LoopEvent, pretty: bool) {
+/// Render one reactive-runtime event (ADR 0005) as pretty text or NDJSON.
+///
+/// `sensed` events are now per-sensor (sensors no longer run as a batched
+/// sweep) and carry a `changed` flag — whether the reading moved the world and
+/// triggered a replan. `planned`/`executed`/`complete` keep their previous JSON
+/// tags; the terminal `complete` event is emitted once, last.
+fn emit_runtime_event(event: &RuntimeEvent, pretty: bool) {
     if pretty {
-        match event {
-            LoopEvent::Sensed {
-                iteration,
-                readings,
-                state,
-                values,
-            } => {
-                let ok_count = readings.iter().filter(|r| r.success).count();
-                println!(
-                    "[{iteration:>3}] sense    {}/{} ok → state({}): {}",
-                    ok_count,
-                    readings.len(),
-                    state.len(),
-                    state.join(", "),
-                );
-                if !values.is_empty() {
-                    let pairs: Vec<String> =
-                        values.iter().map(|(k, v)| format!("{k}={v}")).collect();
-                    println!("      values   {}", pairs.join(", "),);
-                }
+        emit_runtime_event_pretty(event);
+    } else {
+        println!("{}", runtime_event_json(event));
+    }
+}
+
+fn emit_runtime_event_pretty(event: &RuntimeEvent) {
+    match event {
+        RuntimeEvent::Sensed {
+            sensor,
+            success,
+            changed,
+            state,
+            values,
+            ..
+        } => {
+            let status = if *success { "ok" } else { "fail" };
+            let mark = if *changed { "Δ" } else { " " };
+            println!(
+                "{mark} sense    {sensor} [{status}] → state({}): {}",
+                state.len(),
+                state.join(", "),
+            );
+            if *changed && !values.is_empty() {
+                let pairs: Vec<String> = values.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                println!("      values   {}", pairs.join(", "));
             }
-            LoopEvent::Planned { iteration, plan } => match plan {
-                None => println!("[{iteration:>3}] plan     no plan exists"),
-                Some(p) if p.steps.is_empty() => {
-                    println!("[{iteration:>3}] plan     goal satisfied");
-                }
-                Some(p) => println!(
-                    "[{iteration:>3}] plan     {} steps, cost {:.1}: {}",
-                    p.steps.len(),
-                    p.cost,
-                    p.steps.join(" → "),
-                ),
-            },
-            LoopEvent::Executed { iteration, result } => {
-                let status = if result.success { "ok" } else { "FAIL" };
-                println!("[{iteration:>3}] exec     {} ... {status}", result.name);
-                if !result.success && !result.stderr.is_empty() {
-                    for line in result.stderr.lines().take(5) {
-                        println!("            stderr: {line}");
-                    }
+        }
+        RuntimeEvent::Planned { plan } => match plan {
+            None => println!("  plan     no plan exists"),
+            Some(p) if p.steps.is_empty() => println!("  plan     goal satisfied"),
+            Some(p) => println!(
+                "  plan     {} steps, cost {:.1}: {}",
+                p.steps.len(),
+                p.cost,
+                p.steps.join(" → "),
+            ),
+        },
+        RuntimeEvent::Executed { result } => {
+            let status = if result.success { "ok" } else { "FAIL" };
+            println!("  exec     {} ... {status}", result.name);
+            if !result.success && !result.stderr.is_empty() {
+                for line in result.stderr.lines().take(5) {
+                    println!("            stderr: {line}");
                 }
             }
         }
-        return;
-    }
-
-    let v = match event {
-        LoopEvent::Sensed {
-            iteration,
-            readings,
-            state,
-            values,
-        } => serde_json::json!({
-            "event": "sensed",
-            "iteration": iteration,
-            "readings": readings.iter().map(|r| serde_json::json!({
-                "name": r.name,
-                "success": r.success,
-                "added": r.added,
-                "removed": r.removed,
-                "captured_value": r.captured_value,
-            })).collect::<Vec<_>>(),
-            "state": state,
-            "values": values,
-        }),
-        LoopEvent::Planned { iteration, plan } => serde_json::json!({
-            "event": "planned",
-            "iteration": iteration,
-            "plan": plan.as_ref().map(|p| serde_json::json!({
-                "steps": p.steps,
-                "cost": p.cost,
-            })),
-        }),
-        LoopEvent::Executed { iteration, result } => serde_json::json!({
-            "event": "executed",
-            "iteration": iteration,
-            "result": {
-                "name": result.name,
-                "success": result.success,
-                "exit_code": result.exit_code,
-                "stderr": result.stderr,
-            },
-        }),
-    };
-    println!("{v}");
-}
-
-fn emit_loop_outcome(outcome: &LoopOutcome, pretty: bool) {
-    if pretty {
-        match outcome {
-            LoopOutcome::GoalSatisfied { iteration } => {
-                println!("[done]   goal satisfied after {iteration} iteration(s)");
-            }
-            LoopOutcome::NoPlan { iteration } => {
-                println!("[stop]   no plan exists at iteration {iteration}");
-            }
-            LoopOutcome::ActionFailed {
-                iteration,
+        RuntimeEvent::Complete { outcome } => match outcome {
+            RuntimeOutcome::GoalSatisfied => println!("[done]   goal satisfied"),
+            RuntimeOutcome::NoPlan => println!("[stop]   no plan exists"),
+            RuntimeOutcome::ActionFailed {
                 name,
                 exit_code,
                 stderr,
             } => {
                 println!(
-                    "[stop]   action `{name}` failed at iteration {iteration} (exit {})",
+                    "[stop]   action `{name}` failed (exit {})",
                     exit_code
                         .map(|c| c.to_string())
                         .unwrap_or_else(|| "?".into()),
@@ -501,53 +469,89 @@ fn emit_loop_outcome(outcome: &LoopOutcome, pretty: bool) {
                     }
                 }
             }
-            LoopOutcome::Interrupted { iteration } => {
-                println!("[stop]   interrupted after {iteration} iteration(s)");
+            RuntimeOutcome::MaxActionsReached { max } => {
+                println!("[stop]   max actions reached ({max})");
             }
-            LoopOutcome::MaxIterationsReached { iteration, max } => {
-                println!("[stop]   max iterations reached ({iteration}/{max})");
-            }
-        }
-        return;
+            RuntimeOutcome::Interrupted => println!("[stop]   interrupted"),
+            RuntimeOutcome::Error { message } => println!("[error]  {message}"),
+        },
     }
+}
 
-    let v = match outcome {
-        LoopOutcome::GoalSatisfied { iteration } => serde_json::json!({
-            "event": "complete",
-            "outcome": "goal_satisfied",
-            "iterations": iteration,
-        }),
-        LoopOutcome::NoPlan { iteration } => serde_json::json!({
-            "event": "complete",
-            "outcome": "no_plan",
-            "iterations": iteration,
-        }),
-        LoopOutcome::ActionFailed {
-            iteration,
-            name,
-            exit_code,
-            stderr,
+fn runtime_event_json(event: &RuntimeEvent) -> serde_json::Value {
+    match event {
+        RuntimeEvent::Sensed {
+            sensor,
+            success,
+            added,
+            removed,
+            captured,
+            changed,
+            state,
+            values,
         } => serde_json::json!({
-            "event": "complete",
-            "outcome": "action_failed",
-            "iterations": iteration,
-            "action": name,
-            "exit_code": exit_code,
-            "stderr": stderr,
+            "event": "sensed",
+            "sensor": sensor,
+            "success": success,
+            "added": added,
+            "removed": removed,
+            "captured_value": captured,
+            "changed": changed,
+            "state": state,
+            "values": values,
         }),
-        LoopOutcome::Interrupted { iteration } => serde_json::json!({
-            "event": "complete",
-            "outcome": "interrupted",
-            "iterations": iteration,
+        RuntimeEvent::Planned { plan } => serde_json::json!({
+            "event": "planned",
+            "plan": plan.as_ref().map(|p| serde_json::json!({
+                "steps": p.steps,
+                "cost": p.cost,
+            })),
         }),
-        LoopOutcome::MaxIterationsReached { iteration, max } => serde_json::json!({
-            "event": "complete",
-            "outcome": "max_iterations_reached",
-            "iterations": iteration,
-            "max": max,
+        RuntimeEvent::Executed { result } => serde_json::json!({
+            "event": "executed",
+            "result": {
+                "name": result.name,
+                "success": result.success,
+                "exit_code": result.exit_code,
+                "stderr": result.stderr,
+            },
         }),
-    };
-    println!("{v}");
+        RuntimeEvent::Complete { outcome } => match outcome {
+            RuntimeOutcome::GoalSatisfied => serde_json::json!({
+                "event": "complete",
+                "outcome": "goal_satisfied",
+            }),
+            RuntimeOutcome::NoPlan => serde_json::json!({
+                "event": "complete",
+                "outcome": "no_plan",
+            }),
+            RuntimeOutcome::ActionFailed {
+                name,
+                exit_code,
+                stderr,
+            } => serde_json::json!({
+                "event": "complete",
+                "outcome": "action_failed",
+                "action": name,
+                "exit_code": exit_code,
+                "stderr": stderr,
+            }),
+            RuntimeOutcome::MaxActionsReached { max } => serde_json::json!({
+                "event": "complete",
+                "outcome": "max_actions_reached",
+                "max": max,
+            }),
+            RuntimeOutcome::Interrupted => serde_json::json!({
+                "event": "complete",
+                "outcome": "interrupted",
+            }),
+            RuntimeOutcome::Error { message } => serde_json::json!({
+                "event": "complete",
+                "outcome": "error",
+                "error": message,
+            }),
+        },
+    }
 }
 
 fn emit_error(err: &RunError, pretty: bool) {

--- a/uncharles/src/run.rs
+++ b/uncharles/src/run.rs
@@ -1,8 +1,5 @@
 use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
 
 use goap_planner::{Action, Goal, Planner, State};
 
@@ -72,11 +69,17 @@ impl std::fmt::Display for RunError {
 
 impl std::error::Error for RunError {}
 
-pub fn run_sensor(
-    spec: &SensorSpec,
-    state: &mut State,
-    values: &mut Values,
-) -> Result<SensorReading, RunError> {
+/// Execute a sensor command and compute its [`SensorReading`] **without
+/// mutating any state**.
+///
+/// This is the pure-I/O half of sensing: it runs the command, captures
+/// stdout when the sensor opts into [`Capture::Stdout`], and resolves the
+/// effect lists (`added`/`removed`) via [`SensorSpec::effects_for`]. Applying
+/// those effects to a [`State`]/[`Values`] is the caller's job — see
+/// [`apply_reading`]. Splitting read from apply lets the actor runtime (ADR
+/// 0005) run the blocking command off-thread in one actor and apply the
+/// resulting reading in the world-state-owning actor.
+pub fn read_sensor(spec: &SensorSpec) -> Result<SensorReading, RunError> {
     let cmd_name = spec.cmd.first().cloned().unwrap_or_default();
     let mut command = Command::new(&cmd_name);
     command.args(spec.cmd.iter().skip(1)).stderr(Stdio::null());
@@ -117,17 +120,6 @@ pub fn run_sensor(
     };
 
     let effects = spec.effects_for(success);
-    for fact in &effects.add {
-        state.insert(fact.clone());
-    }
-    if let Some(ref v) = captured_value {
-        values.insert(spec.name.clone(), v.clone());
-    }
-    for fact in &effects.remove {
-        state.remove(fact);
-        values.remove(fact);
-    }
-
     Ok(SensorReading {
         name: spec.name.clone(),
         success,
@@ -135,6 +127,40 @@ pub fn run_sensor(
         removed: effects.remove,
         captured_value,
     })
+}
+
+/// Apply a [`SensorReading`]'s effects to `state` and `values`.
+///
+/// The pure-mutation half of sensing (see [`read_sensor`]). Adds every fact
+/// in `reading.added`, stores the captured value (if any) under the sensor's
+/// name, and removes every fact in `reading.removed` — dropping its value too,
+/// per ADR 0003's atomic-remove rule.
+pub fn apply_reading(reading: &SensorReading, state: &mut State, values: &mut Values) {
+    for fact in &reading.added {
+        state.insert(fact.clone());
+    }
+    if let Some(ref v) = reading.captured_value {
+        values.insert(reading.name.clone(), v.clone());
+    }
+    for fact in &reading.removed {
+        state.remove(fact);
+        values.remove(fact);
+    }
+}
+
+/// Run a sensor and apply its effects in one step.
+///
+/// Thin composition of [`read_sensor`] + [`apply_reading`], retained for the
+/// one-shot [`sense_and_plan`] path and as the unit under test for the sensor
+/// effect contract. The actor runtime calls the two halves separately.
+pub fn run_sensor(
+    spec: &SensorSpec,
+    state: &mut State,
+    values: &mut Values,
+) -> Result<SensorReading, RunError> {
+    let reading = read_sensor(spec)?;
+    apply_reading(&reading, state, values);
+    Ok(reading)
 }
 
 pub fn execute_action(spec: &ActionSpec, values: &Values) -> Result<ActionResult, RunError> {
@@ -195,30 +221,14 @@ pub(crate) fn fact_env_var(fact: &str) -> String {
     s
 }
 
-/// Sleep for up to `total_ms` milliseconds, waking early if `interrupted`
-/// becomes true. The poll slice is short (50 ms) so SIGINT remains responsive
-/// even when the configured interval is long.
-fn interruptible_sleep(total_ms: u64, interrupted: &AtomicBool) {
-    if total_ms == 0 {
-        return;
-    }
-    let total = Duration::from_millis(total_ms);
-    let slice = Duration::from_millis(50);
-    let start = Instant::now();
-    loop {
-        if interrupted.load(Ordering::Relaxed) {
-            return;
-        }
-        let elapsed = start.elapsed();
-        if elapsed >= total {
-            return;
-        }
-        let remaining = total - elapsed;
-        std::thread::sleep(remaining.min(slice));
-    }
-}
-
-fn find_action_spec<'a>(specs: &'a [ActionSpec], name: &str) -> Result<&'a ActionSpec, RunError> {
+/// Find an [`ActionSpec`] by name, or return [`RunError::PlannerActionMismatch`].
+///
+/// Used by the executor actor (ADR 0005) to resolve a planner-named step back
+/// to its config spec before running its `cmd`.
+pub(crate) fn find_action_spec<'a>(
+    specs: &'a [ActionSpec],
+    name: &str,
+) -> Result<&'a ActionSpec, RunError> {
     specs
         .iter()
         .find(|a| a.name == name)
@@ -291,183 +301,6 @@ pub fn sense_and_plan(config: &Config, seed: Vec<String>) -> Result<Outcome, Run
         values,
         plan,
     })
-}
-
-#[derive(Debug)]
-pub enum LoopEvent {
-    Sensed {
-        iteration: usize,
-        readings: Vec<SensorReading>,
-        state: Vec<String>,
-        values: Values,
-    },
-    Planned {
-        iteration: usize,
-        plan: Option<goap_planner::Plan>,
-    },
-    Executed {
-        iteration: usize,
-        result: ActionResult,
-    },
-}
-
-#[derive(Debug)]
-pub enum LoopOutcome {
-    GoalSatisfied {
-        iteration: usize,
-    },
-    NoPlan {
-        iteration: usize,
-    },
-    ActionFailed {
-        iteration: usize,
-        name: String,
-        exit_code: Option<i32>,
-        stderr: String,
-    },
-    Interrupted {
-        iteration: usize,
-    },
-    MaxIterationsReached {
-        iteration: usize,
-        max: usize,
-    },
-}
-
-/// Drive the sense → plan → execute loop until the goal is satisfied, the
-/// planner reports no path, an action fails without an `on_failure` clause,
-/// the iteration cap is hit, or `interrupted` flips to true (signal handler).
-///
-/// Replanning is automatic: each iteration re-runs every sensor and re-plans
-/// from the resulting [`State`]. If reality diverges from the planner's
-/// expectation (sensor for `image_built` reports false after `docker_build`
-/// "succeeded"), the next iteration's planner sees the new state and either
-/// finds a different path or returns [`LoopOutcome::NoPlan`].
-///
-/// When an action's `cmd` exits non-zero, behaviour depends on whether the
-/// action declares an `on_failure` clause:
-///
-/// - **Without `on_failure`**: the loop terminates with
-///   [`LoopOutcome::ActionFailed`]. This is the default; failure is fatal.
-/// - **With `on_failure`**: the listed adds/removes are applied to state,
-///   the loop sleeps for `interval_ms`, and the next iteration replans from
-///   the resulting state. The action's own `adds`/`removes` are *not*
-///   applied — those describe the success-path contract for the planner.
-///   If the planner can find an alternative, the loop continues; if not,
-///   the next iteration returns [`LoopOutcome::NoPlan`] cleanly.
-///
-/// `interval_ms` is the minimum delay (in milliseconds) between iterations
-/// after a successful action execution. `0` means run as fast as work allows
-/// — appropriate for "drive to goal" use cases. A non-zero value paces
-/// "watch the world" configs that would otherwise hammer external sensors in
-/// a tight goal-satisfied loop. The sleep is interruptible: SIGINT wakes it
-/// in at most ~50 ms regardless of the configured interval.
-///
-/// Returns [`RunError::PlannerActionMismatch`] if the planner ever names an
-/// action that is not present in `config.actions`. This is a programming-bug
-/// invariant under the current single-source-of-actions model, but is surfaced
-/// as a typed error so callers can report it cleanly rather than panic.
-pub fn run_loop(
-    config: &Config,
-    seed: Vec<String>,
-    max_iterations: usize,
-    interval_ms: u64,
-    interrupted: Arc<AtomicBool>,
-    mut on_event: impl FnMut(LoopEvent),
-) -> Result<LoopOutcome, RunError> {
-    let mut state = State::from_facts(seed);
-    let mut values = Values::new();
-    let actions = build_actions(&config.actions);
-    let goal = build_goal(&config.goal);
-    let planner = Planner::new(actions);
-
-    let mut iteration = 0;
-
-    loop {
-        if interrupted.load(Ordering::Relaxed) {
-            return Ok(LoopOutcome::Interrupted { iteration });
-        }
-        if iteration >= max_iterations {
-            return Ok(LoopOutcome::MaxIterationsReached {
-                iteration,
-                max: max_iterations,
-            });
-        }
-        iteration += 1;
-
-        let mut readings = Vec::with_capacity(config.sensors.len());
-        for sensor in &config.sensors {
-            readings.push(run_sensor(sensor, &mut state, &mut values)?);
-        }
-        let mut state_facts: Vec<String> = state.facts().map(String::from).collect();
-        state_facts.sort();
-        on_event(LoopEvent::Sensed {
-            iteration,
-            readings,
-            state: state_facts,
-            values: values.clone(),
-        });
-
-        let plan = planner.plan(&state, &goal).map_err(RunError::Planner)?;
-        on_event(LoopEvent::Planned {
-            iteration,
-            plan: plan.clone(),
-        });
-
-        match plan {
-            None => return Ok(LoopOutcome::NoPlan { iteration }),
-            Some(p) if p.steps.is_empty() => {
-                return Ok(LoopOutcome::GoalSatisfied { iteration });
-            }
-            Some(p) => {
-                let next = &p.steps[0];
-                let spec = find_action_spec(&config.actions, next)?;
-                let result = execute_action(spec, &values)?;
-                let result_for_event = result.clone();
-                on_event(LoopEvent::Executed {
-                    iteration,
-                    result: result_for_event,
-                });
-                if !result.success {
-                    let Some(failure_effects) = &spec.on_failure else {
-                        return Ok(LoopOutcome::ActionFailed {
-                            iteration,
-                            name: result.name,
-                            exit_code: result.exit_code,
-                            stderr: result.stderr,
-                        });
-                    };
-                    // Failure is recoverable: apply the on_failure effects
-                    // and let the next iteration replan. The action's own
-                    // adds/removes are skipped — those describe the
-                    // success-path contract, not the failure aftermath.
-                    for fact in &failure_effects.remove {
-                        state.remove(fact);
-                        values.remove(fact);
-                    }
-                    for fact in &failure_effects.add {
-                        state.insert(fact.clone());
-                    }
-                    interruptible_sleep(interval_ms, &interrupted);
-                    continue;
-                }
-                // Optimistically apply the action's declared effects so the
-                // next iteration plans from the expected post-state. Sensors
-                // run again at the top of the next iteration and will correct
-                // the state if reality disagrees — that's the replan trigger.
-                // Removing a fact also drops its captured value: ADR 0003
-                // commits to atomic fact-and-value lifetimes.
-                for fact in &spec.removes {
-                    state.remove(fact);
-                    values.remove(fact);
-                }
-                for fact in &spec.adds {
-                    state.insert(fact.clone());
-                }
-                interruptible_sleep(interval_ms, &interrupted);
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -817,63 +650,6 @@ mod tests {
         assert_eq!(spec.name, "b");
     }
 
-    // ---------------------------------------------------------------------
-    // interruptible_sleep — pacing primitive used by run_loop's --interval-ms
-    // ---------------------------------------------------------------------
-
-    #[test]
-    fn interruptible_sleep_zero_returns_immediately() {
-        let interrupted = AtomicBool::new(false);
-        let start = Instant::now();
-        interruptible_sleep(0, &interrupted);
-        assert!(
-            start.elapsed() < Duration::from_millis(20),
-            "zero interval must not sleep"
-        );
-    }
-
-    #[test]
-    fn interruptible_sleep_waits_at_least_the_configured_interval() {
-        let interrupted = AtomicBool::new(false);
-        let start = Instant::now();
-        interruptible_sleep(120, &interrupted);
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed >= Duration::from_millis(120),
-            "expected ≥120 ms, got {elapsed:?}"
-        );
-        // Generous upper bound — we only care it doesn't run away.
-        assert!(
-            elapsed < Duration::from_millis(800),
-            "expected <800 ms, got {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn interruptible_sleep_wakes_early_when_interrupted_is_set_mid_wait() {
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let flag = Arc::clone(&interrupted);
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(60));
-            flag.store(true, Ordering::Relaxed);
-        });
-        let start = Instant::now();
-        interruptible_sleep(5_000, &interrupted);
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_millis(500),
-            "expected interrupt to wake sleep promptly, got {elapsed:?}"
-        );
-    }
-
-    // ---------------------------------------------------------------------
-    // run_loop — termination conditions
-    // ---------------------------------------------------------------------
-
-    fn drain_events(events: &mut Vec<LoopEvent>) -> impl FnMut(LoopEvent) + '_ {
-        |e| events.push(e)
-    }
-
     fn three_step_config() -> Config {
         Config {
             sensors: vec![sensor("heartbeat", &["true"])],
@@ -887,286 +663,6 @@ mod tests {
                 forbids: Vec::new(),
             },
         }
-    }
-
-    #[test]
-    fn loop_terminates_at_goal_satisfied() {
-        let config = three_step_config();
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let mut events = Vec::new();
-        let outcome = run_loop(
-            &config,
-            Vec::new(),
-            100,
-            0,
-            Arc::clone(&interrupted),
-            drain_events(&mut events),
-        )
-        .unwrap();
-        match outcome {
-            LoopOutcome::GoalSatisfied { iteration } => assert_eq!(iteration, 4),
-            other => panic!("expected GoalSatisfied, got {other:?}"),
-        }
-        // 4 sense + 4 plan + 3 exec = 11 events.
-        assert_eq!(events.len(), 11);
-    }
-
-    #[test]
-    fn loop_returns_no_plan_when_goal_unreachable() {
-        let mut config = three_step_config();
-        config.goal.requires = vec!["never_set".into()];
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let outcome =
-            run_loop(&config, Vec::new(), 10, 0, Arc::clone(&interrupted), |_| {}).unwrap();
-        assert!(matches!(outcome, LoopOutcome::NoPlan { iteration: 1 }));
-    }
-
-    #[test]
-    fn loop_stops_on_action_failure_and_surfaces_stderr() {
-        let mut config = three_step_config();
-        config.actions[0] = action(
-            "do_a",
-            &["sh", "-c", "echo nope >&2; exit 3"],
-            &["heartbeat"],
-            &["a_done"],
-        );
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let outcome =
-            run_loop(&config, Vec::new(), 10, 0, Arc::clone(&interrupted), |_| {}).unwrap();
-        match outcome {
-            LoopOutcome::ActionFailed {
-                iteration,
-                name,
-                exit_code,
-                stderr,
-            } => {
-                assert_eq!(iteration, 1);
-                assert_eq!(name, "do_a");
-                assert_eq!(exit_code, Some(3));
-                assert_eq!(stderr, "nope");
-            }
-            other => panic!("expected ActionFailed, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn loop_respects_max_iterations_cap() {
-        // Sensor that adds heartbeat; action is a no-op that doesn't add the
-        // expected fact via sensor (no sensor for a_done), but optimistic
-        // effect application means do_a → a_done → goal in 2 iterations.
-        // To force the cap to bite, model a never-satisfiable scenario.
-        let config = Config {
-            sensors: vec![sensor("heartbeat", &["true"])],
-            actions: vec![
-                // Action with a precondition that never becomes true → no plan.
-                // But that returns NoPlan, not MaxIterations. Instead, build a
-                // config where each iteration makes no progress: action's
-                // effects are sensor-overridden every iteration.
-                ActionSpec {
-                    name: "loop_action".into(),
-                    cost: 1.0,
-                    requires: vec!["heartbeat".into()],
-                    forbids: Vec::new(),
-                    adds: vec!["progress".into()],
-                    removes: Vec::new(),
-                    cmd: Some(vec!["true".into()]),
-                    on_failure: None,
-                },
-            ],
-            goal: GoalSpec {
-                requires: vec!["unreachable_fact".into()],
-                forbids: Vec::new(),
-            },
-        };
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let outcome =
-            run_loop(&config, Vec::new(), 5, 0, Arc::clone(&interrupted), |_| {}).unwrap();
-        // Goal unreachable → NoPlan on first iteration, before max kicks in.
-        // This is correct behaviour: NoPlan is the natural terminator when
-        // the planner can't find a path, and is preferred over spinning.
-        assert!(matches!(outcome, LoopOutcome::NoPlan { iteration: 1 }));
-    }
-
-    #[test]
-    fn loop_returns_interrupted_when_flag_is_set_before_first_iteration() {
-        let config = three_step_config();
-        let interrupted = Arc::new(AtomicBool::new(true));
-        let outcome =
-            run_loop(&config, Vec::new(), 10, 0, Arc::clone(&interrupted), |_| {}).unwrap();
-        assert!(matches!(outcome, LoopOutcome::Interrupted { iteration: 0 }));
-    }
-
-    #[test]
-    fn loop_with_nonzero_interval_paces_iterations() {
-        // Three actions × ~60 ms inter-iteration sleep ≈ ≥120 ms (the sleep
-        // fires after each successful exec; the final iteration plans an
-        // empty plan and returns without sleeping).
-        let config = three_step_config();
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let start = Instant::now();
-        let outcome = run_loop(
-            &config,
-            Vec::new(),
-            100,
-            60,
-            Arc::clone(&interrupted),
-            |_| {},
-        )
-        .unwrap();
-        let elapsed = start.elapsed();
-        assert!(matches!(
-            outcome,
-            LoopOutcome::GoalSatisfied { iteration: 4 }
-        ));
-        assert!(
-            elapsed >= Duration::from_millis(180),
-            "expected ≥180 ms with --interval-ms=60 across 3 execs, got {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn loop_with_action_on_failure_replans_through_alternative_path() {
-        // `try_fast` fails (`cmd: false`) but its on_failure removes
-        // `fast_path_available` (its own precondition, locking it out)
-        // and adds `slow_path_unlocked` (the alternative's precondition).
-        // The loop must absorb the failure, replan, and reach the goal
-        // via `try_slow`.
-        let config = Config {
-            sensors: vec![sensor("heartbeat", &["true"])],
-            actions: vec![
-                ActionSpec {
-                    name: "try_fast".into(),
-                    cost: 1.0,
-                    requires: vec!["heartbeat".into(), "fast_path_available".into()],
-                    forbids: Vec::new(),
-                    adds: vec!["finished".into()],
-                    removes: Vec::new(),
-                    cmd: Some(vec!["false".into()]),
-                    on_failure: Some(Effects {
-                        add: vec!["slow_path_unlocked".into()],
-                        remove: vec!["fast_path_available".into()],
-                    }),
-                },
-                ActionSpec {
-                    name: "try_slow".into(),
-                    cost: 5.0,
-                    requires: vec!["slow_path_unlocked".into()],
-                    forbids: Vec::new(),
-                    adds: vec!["finished".into()],
-                    removes: Vec::new(),
-                    cmd: Some(vec!["true".into()]),
-                    on_failure: None,
-                },
-            ],
-            goal: GoalSpec {
-                requires: vec!["finished".into()],
-                forbids: Vec::new(),
-            },
-        };
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let mut events = Vec::new();
-        let outcome = run_loop(
-            &config,
-            vec!["fast_path_available".into()],
-            10,
-            0,
-            Arc::clone(&interrupted),
-            drain_events(&mut events),
-        )
-        .unwrap();
-        match outcome {
-            // Iteration 1: try_fast → fail → on_failure mutates state.
-            // Iteration 2: planner picks try_slow → succeeds.
-            // Iteration 3: empty plan → goal satisfied.
-            LoopOutcome::GoalSatisfied { iteration } => assert_eq!(iteration, 3),
-            other => panic!("expected GoalSatisfied, got {other:?}"),
-        }
-
-        let executed: Vec<(String, bool)> = events
-            .iter()
-            .filter_map(|e| match e {
-                LoopEvent::Executed { result, .. } => Some((result.name.clone(), result.success)),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            executed,
-            vec![
-                ("try_fast".to_string(), false),
-                ("try_slow".to_string(), true),
-            ],
-            "expected try_fast to fail then try_slow to succeed",
-        );
-    }
-
-    #[test]
-    fn loop_with_action_on_failure_returns_no_plan_when_no_alternative_exists() {
-        // `only_path` is the only way to reach `done`; on failure it
-        // removes its own precondition and adds nothing useful. The next
-        // iteration's planner sees no path → NoPlan.
-        let config = Config {
-            sensors: vec![sensor("heartbeat", &["true"])],
-            actions: vec![ActionSpec {
-                name: "only_path".into(),
-                cost: 1.0,
-                requires: vec!["heartbeat".into(), "available".into()],
-                forbids: Vec::new(),
-                adds: vec!["done".into()],
-                removes: Vec::new(),
-                cmd: Some(vec!["false".into()]),
-                on_failure: Some(Effects {
-                    add: Vec::new(),
-                    remove: vec!["available".into()],
-                }),
-            }],
-            goal: GoalSpec {
-                requires: vec!["done".into()],
-                forbids: Vec::new(),
-            },
-        };
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let outcome = run_loop(
-            &config,
-            vec!["available".into()],
-            10,
-            0,
-            Arc::clone(&interrupted),
-            |_| {},
-        )
-        .unwrap();
-        // Iteration 1: only_path runs, fails, on_failure removes `available`.
-        // Iteration 2: planner has no path to `done` → NoPlan.
-        assert!(matches!(outcome, LoopOutcome::NoPlan { iteration: 2 }));
-    }
-
-    #[test]
-    fn loop_with_long_interval_wakes_promptly_on_interrupt() {
-        let config = three_step_config();
-        let interrupted = Arc::new(AtomicBool::new(false));
-        let flag = Arc::clone(&interrupted);
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(100));
-            flag.store(true, Ordering::Relaxed);
-        });
-        let start = Instant::now();
-        let outcome = run_loop(
-            &config,
-            Vec::new(),
-            100,
-            10_000,
-            Arc::clone(&interrupted),
-            |_| {},
-        )
-        .unwrap();
-        let elapsed = start.elapsed();
-        assert!(
-            matches!(outcome, LoopOutcome::Interrupted { .. }),
-            "expected Interrupted, got {outcome:?}"
-        );
-        assert!(
-            elapsed < Duration::from_millis(1_000),
-            "10s interval must yield to interrupt within ~1s, got {elapsed:?}"
-        );
     }
 
     // ---------------------------------------------------------------------

--- a/uncharles/src/run.rs
+++ b/uncharles/src/run.rs
@@ -208,7 +208,7 @@ pub fn execute_action(spec: &ActionSpec, values: &Values) -> Result<ActionResult
 /// fact names that collide here would clash in the child environment, but
 /// such names are exotic enough that the collision is acceptable
 /// (documented in ADR 0003).
-pub(crate) fn fact_env_var(fact: &str) -> String {
+pub fn fact_env_var(fact: &str) -> String {
     let mut s = String::with_capacity("UNCHARLES_FACT_".len() + fact.len());
     s.push_str("UNCHARLES_FACT_");
     for c in fact.chars() {
@@ -225,7 +225,7 @@ pub(crate) fn fact_env_var(fact: &str) -> String {
 ///
 /// Used by the executor actor (ADR 0005) to resolve a planner-named step back
 /// to its config spec before running its `cmd`.
-pub(crate) fn find_action_spec<'a>(
+pub fn find_action_spec<'a>(
     specs: &'a [ActionSpec],
     name: &str,
 ) -> Result<&'a ActionSpec, RunError> {
@@ -311,7 +311,7 @@ mod tests {
     fn sensor(name: &str, cmd: &[&str]) -> SensorSpec {
         SensorSpec {
             name: name.into(),
-            cmd: cmd.iter().map(|s| s.to_string()).collect(),
+            cmd: cmd.iter().map(std::string::ToString::to_string).collect(),
             on_success: None,
             on_failure: None,
             capture: None,
@@ -322,11 +322,14 @@ mod tests {
         ActionSpec {
             name: name.into(),
             cost: 1.0,
-            requires: requires.iter().map(|s| s.to_string()).collect(),
+            requires: requires
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             forbids: Vec::new(),
-            adds: adds.iter().map(|s| s.to_string()).collect(),
+            adds: adds.iter().map(std::string::ToString::to_string).collect(),
             removes: Vec::new(),
-            cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
+            cmd: Some(cmd.iter().map(std::string::ToString::to_string).collect()),
             on_failure: None,
         }
     }

--- a/uncharles/tests/cli.rs
+++ b/uncharles/tests/cli.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn binary() -> &'static str {
+const fn binary() -> &'static str {
     env!("CARGO_BIN_EXE_uncharles")
 }
 
@@ -451,8 +451,7 @@ fn execute_loop_drives_podcast_pipeline_end_to_end() {
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_nanos()),
     ));
     let _ = fs::remove_dir_all(&work_dir);
     fs::create_dir_all(&work_dir).unwrap();
@@ -527,7 +526,7 @@ fn execute_loop_drives_podcast_pipeline_end_to_end() {
     );
 
     let pending = state.join("pending");
-    let pending_count = fs::read_dir(&pending).map(|d| d.count()).unwrap_or(0);
+    let pending_count = fs::read_dir(&pending).map_or(0, std::iter::Iterator::count);
     assert_eq!(
         pending_count, 0,
         "pending/ should be empty after commit — commit_cycle regression",

--- a/uncharles/tests/cli.rs
+++ b/uncharles/tests/cli.rs
@@ -7,7 +7,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{Duration, Instant};
 
 fn binary() -> &'static str {
     env!("CARGO_BIN_EXE_uncharles")
@@ -43,7 +42,11 @@ fn one_shot_emits_json_plan_and_exits_zero() {
 }
 
 #[test]
-fn execute_loop_drives_smoke_config_to_goal() {
+fn execute_reactive_runtime_drives_smoke_config_to_goal() {
+    // The reactive runtime (ADR 0005) replans after each action's effects land,
+    // walking do_a → do_b → do_c to the goal. Exact event *counts* are no
+    // longer pinned (sensing is continuous), but the executed-action sequence
+    // and terminal outcome are deterministic for this `true`-only config.
     let output = Command::new(binary())
         .arg("--config")
         .arg(config_path("smoke_loop.yaml"))
@@ -56,15 +59,25 @@ fn execute_loop_drives_smoke_config_to_goal() {
         output.status
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
-    let last_line = stdout
+    let events: Vec<serde_json::Value> = stdout
         .lines()
-        .last()
-        .expect("expected at least one NDJSON line");
-    let final_event: serde_json::Value =
-        serde_json::from_str(last_line).expect("final line must be JSON");
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    let final_event = events.last().expect("expected at least one NDJSON event");
     assert_eq!(final_event["event"], "complete");
     assert_eq!(final_event["outcome"], "goal_satisfied");
-    assert_eq!(final_event["iterations"], 4);
+
+    let executed: Vec<&str> = events
+        .iter()
+        .filter(|e| e["event"] == "executed")
+        .map(|e| e["result"]["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        executed,
+        vec!["do_a", "do_b", "do_c"],
+        "expected the replan loop to execute the three actions in order"
+    );
 }
 
 #[test]
@@ -128,25 +141,23 @@ fn missing_config_file_exits_two() {
 }
 
 #[test]
-fn execute_loop_with_interval_ms_paces_iterations() {
-    // smoke_loop runs 3 actions; with --interval-ms=120 the inter-iteration
-    // sleep fires after each successful exec, so wall clock should be at
-    // least 360 ms (3 × 120 ms). Loose upper bound to keep CI noise out.
-    let start = Instant::now();
+fn execute_with_sensor_poll_interval_still_reaches_goal() {
+    // Under the reactive runtime (ADR 0005) `--interval-ms` is the per-sensor
+    // poll cadence, not an inter-action sleep — action execution is no longer
+    // gated by it. The flag must still parse and the run must drive to goal.
     let output = Command::new(binary())
         .arg("--config")
         .arg(config_path("smoke_loop.yaml"))
         .arg("--execute")
         .arg("--interval-ms")
-        .arg("120")
+        .arg("50")
         .output()
         .expect("failed to spawn uncharles");
-    let elapsed = start.elapsed();
     assert!(output.status.success(), "expected exit 0 (goal satisfied)");
-    assert!(
-        elapsed >= Duration::from_millis(360),
-        "expected ≥360 ms wall clock with --interval-ms=120, got {elapsed:?}"
-    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let last_line = stdout.lines().last().unwrap();
+    let final_event: serde_json::Value = serde_json::from_str(last_line).unwrap();
+    assert_eq!(final_event["outcome"], "goal_satisfied");
 }
 
 #[test]
@@ -399,21 +410,15 @@ fn execute_loop_captures_sensor_stdout_and_injects_into_action_env() {
     let last = events.last().unwrap();
     assert_eq!(last["outcome"], "goal_satisfied");
 
-    // `target` sensor reports its captured value on every iteration. Use
-    // the first sensed event for assertion stability.
-    let first_sensed = events
+    // Sensed events are now per-sensor (ADR 0005). Find the `target` sensor's
+    // first reading and assert it captured its stdout into the values map.
+    let target_sensed = events
         .iter()
-        .find(|e| e["event"] == "sensed")
-        .expect("expected a sensed event");
-    let target_reading = first_sensed["readings"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|r| r["name"] == "target")
-        .expect("target sensor reading missing");
-    assert_eq!(target_reading["captured_value"], "abc-123");
-    assert_eq!(target_reading["success"], true);
-    assert_eq!(first_sensed["values"]["target"], "abc-123");
+        .find(|e| e["event"] == "sensed" && e["sensor"] == "target")
+        .expect("expected a sensed event for the target sensor");
+    assert_eq!(target_sensed["captured_value"], "abc-123");
+    assert_eq!(target_sensed["success"], true);
+    assert_eq!(target_sensed["values"]["target"], "abc-123");
 
     // emit_value's stderr proves UNCHARLES_FACT_TARGET was injected.
     let emit_executed = events

--- a/uncharles/tests/cli.rs
+++ b/uncharles/tests/cli.rs
@@ -51,6 +51,7 @@ fn execute_reactive_runtime_drives_smoke_config_to_goal() {
         .arg("--config")
         .arg(config_path("smoke_loop.yaml"))
         .arg("--execute")
+        .arg("--once")
         .output()
         .expect("failed to spawn uncharles");
     assert!(
@@ -86,6 +87,7 @@ fn execute_loop_stops_on_action_failure_and_exits_nonzero() {
         .arg("--config")
         .arg(config_path("smoke_failure.yaml"))
         .arg("--execute")
+        .arg("--once")
         .output()
         .expect("failed to spawn uncharles");
     assert_eq!(
@@ -149,6 +151,7 @@ fn execute_with_sensor_poll_interval_still_reaches_goal() {
         .arg("--config")
         .arg(config_path("smoke_loop.yaml"))
         .arg("--execute")
+        .arg("--once")
         .arg("--interval-ms")
         .arg("50")
         .output()
@@ -391,6 +394,7 @@ fn execute_loop_captures_sensor_stdout_and_injects_into_action_env() {
         .arg("--config")
         .arg(config_path("smoke_capture.yaml"))
         .arg("--execute")
+        .arg("--once")
         .output()
         .expect("failed to spawn uncharles");
     assert!(
@@ -466,6 +470,7 @@ fn execute_loop_drives_podcast_pipeline_end_to_end() {
         .arg("--config")
         .arg(config_path("podcast.yaml"))
         .arg("--execute")
+        .arg("--once")
         .output()
         .expect("failed to spawn uncharles");
 
@@ -555,6 +560,7 @@ fn execute_loop_recovers_via_action_on_failure() {
         .arg("--config")
         .arg(config_path("smoke_recover.yaml"))
         .arg("--execute")
+        .arg("--once")
         .arg("--have")
         .arg("fast_path_available")
         .output()

--- a/uncharles/tests/inspect.rs
+++ b/uncharles/tests/inspect.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn binary() -> &'static str {
+const fn binary() -> &'static str {
     env!("CARGO_BIN_EXE_uncharles")
 }
 


### PR DESCRIPTION
## Summary

- Replace `uncharles`'s synchronous `run_loop` with an **actor-based reactive runtime** ([kameo](https://docs.rs/kameo) on tokio): sensors poll continuously and in parallel, world-state changes edge-trigger replanning, and an executor runs the freshest plan one action at a time, never aborting mid-action.
- Foundation for the committed roadmap (plugins, multi-goal, hot-reload). Decision and the kameo-over-ractor reversal are recorded in **ADR 0005**.
- `goap-planner` and `grafo` are untouched — their `State`/`Goal`/`Action`/`Plan`/`Planner` types are the messages that flow through the actors; the bench gate keeps its signal.

## Conventional commit

Type (check one):

- [x] `feat` — new user-visible capability

Scope: `uncharles`

## Breaking changes

Under `--execute`, NDJSON output changed: `sensed` events are now **per-sensor** with a `changed` flag (no `readings` array, no `iterations` field); `--interval-ms` is now the **per-sensor poll cadence** rather than an inter-iteration sleep; `--max-iterations` caps **executed actions**. One-shot `run` and `inspect` output are unchanged.

`BREAKING CHANGE:` `--execute` NDJSON event shape and `--interval-ms` semantics changed (see above).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (10 suites green; ran the uncharles suite 5× — no flakiness)
- [x] Manual verification: drove `smoke_loop.yaml`, `smoke_failure.yaml`, `smoke_capture.yaml`, and `podcast.yaml` end-to-end under `--execute`; confirmed goal-satisfied / action-failed exit codes, ADR-0003 value injection + privacy invariant, and edge-triggered replanning.

## Linked issues

Refs #17 (watcher mode — realized as `--watch`), Refs #19 (sensor ordering foot-gun — subsumed by parallel sensing).
